### PR TITLE
Stripped out Nones when they are wrapped in iterables

### DIFF
--- a/docassemble/MACourts/macourts.py
+++ b/docassemble/MACourts/macourts.py
@@ -334,6 +334,7 @@ class MACourtList(DAList):
                     pass
                 res = self.matching_courts_single_address(add, court_types)
                 if isinstance(res, Iterable):
+                    res = filter(lambda el: el is not None, res)
                     courts.update(res)
                 elif not res is None:
                     courts.add(res)
@@ -370,6 +371,7 @@ class MACourtList(DAList):
               if court_type in court_type_map:
                 res =  court_type_map[court_type](address)
                 if isinstance(res, Iterable):
+                    res = filter(lambda el: el is not None, res)
                     matches.update(res)
                 elif not res is None:
                     matches.add(res)


### PR DESCRIPTION
Had an issue when running the library on a local docker instance of Docassemble: the location question of in ALMassachusetts (https://github.com/SuffolkLITLab/docassemble-ALMassachusetts/blob/main/docassemble/ALMassachusetts/data/questions/al_massachusetts.yml#L139-L177) wasn't properly setting `trial_court`, because `all_courts` was a single list of one `None` value. 

Felt best to fix it at the source. I didn't dive in further past where I made these changes, so I'm not sure when these pesky `None`s are being generated. It does likely have something to do with the server not having access to Google Maps API, but that seems like it should be avoidable.