### PR TITLE
Lower court codes

### DIFF
--- a/docassemble/MACourts/data/sources/bmc.json
+++ b/docassemble/MACourts/data/sources/bmc.json
@@ -17,7 +17,8 @@
       "state": "MA",
       "address": "52 Academy Hill Rd."
     },
-    "description": "The Brighton division of the BMC serves Allston and Brighton. Please note that as of March 1, the Brighton Division of the Boston Municipal Court has temporarily relocated to Brookline District Court while the Brighton courthouse undergoes renovations. "
+    "description": "The Brighton division of the BMC serves Allston and Brighton. Please note that as of March 1, the Brighton Division of the Boston Municipal Court has temporarily relocated to Brookline District Court while the Brighton courthouse undergoes renovations. ",
+    "lower_court_code": "1753"
   },
   {
     "fax": "(617) 788-8465",
@@ -37,7 +38,8 @@
       "state": "MA",
       "address": "24 New Chardon Street"
     },
-    "description": "This court serves the Downtown Boston area, Chinatown, North End, South End through Massachusetts Avenue, West End, and Beacon Hill."
+    "description": "This court serves the Downtown Boston area, Chinatown, North End, South End through Massachusetts Avenue, West End, and Beacon Hill.",
+    "lower_court_code": "1754"
   },
   {
     "fax": "(617) 242-1677",
@@ -57,7 +59,8 @@
       "state": "MA",
       "address": "3 City Square"
     },
-    "description": "The Charlestown Division of the Boston Municipal Court serves Charlestown."
+    "description": "The Charlestown Division of the Boston Municipal Court serves Charlestown.",
+    "lower_court_code": "1755"
   },
   {
     "fax": "(617) 436-8250 ",
@@ -77,7 +80,8 @@
       "state": "MA",
       "address": "510 Washington St."
     },
-    "description": "This court serves Dorchester."
+    "description": "This court serves Dorchester.",
+    "lower_court_code": "1756"
   },
   {
     "fax": "(617) 561-4988 ",
@@ -97,7 +101,8 @@
       "state": "MA",
       "address": "37 Meridian St."
     },
-    "description": "This court serves East Boston, Winthrop, Logan Airport, and the Sumner and Callahan Tunnels."
+    "description": "This court serves East Boston, Winthrop, Logan Airport, and the Sumner and Callahan Tunnels.",
+    "lower_court_code": "1757"
   },
   {
     "fax": "(617) 541-0286",
@@ -117,7 +122,8 @@
       "state": "MA",
       "address": "85 Warren St."
     },
-    "description": "This court serves Roxbury."
+    "description": "This court serves Roxbury.",
+    "lower_court_code": "1758"
   },
   {
     "fax": "(617) 983-0243 ",
@@ -137,7 +143,8 @@
       "state": "MA",
       "address": "445 Arborway"
     },
-    "description": "This court serves Hyde Park, Jamaica Plain, Roslindale, West Roxbury, parts of Mattapan, and parts of Mission Hill."
+    "description": "This court serves Hyde Park, Jamaica Plain, Roslindale, West Roxbury, parts of Mattapan, and parts of Mission Hill.",
+    "lower_court_code": "1760"
   },
   {
     "fax": "(617) 268-7321",
@@ -157,6 +164,7 @@
       "state": "MA",
       "address": "535 East Broadway"
     },
-    "description": "This court serves South Boston."
+    "description": "This court serves South Boston.",
+    "lower_court_code": "1759"
   }
 ]

--- a/docassemble/MACourts/data/sources/bmc.json
+++ b/docassemble/MACourts/data/sources/bmc.json
@@ -2,7 +2,7 @@
   {
     "fax": "(617) 254-2127",
     "court_code": "08",
-    "lower_court_code": "1753",
+    "tyler_lower_court_code": "1753",
     "name": "Brighton Division, Boston Municipal Court",
     "phone": "(617) 782-6540, Press 5",
     "has_po_box": false,
@@ -23,7 +23,7 @@
   {
     "fax": "(617) 788-8465",
     "court_code": "01",
-    "lower_court_code": "1754",
+    "tyler_lower_court_code": "1754",
     "name": "Central Division, Boston Municipal Court",
     "phone": "(617) 788-8600",
     "has_po_box": false,
@@ -44,7 +44,7 @@
   {
     "fax": "(617) 242-1677",
     "court_code": "04",
-    "lower_court_code": "1755",
+    "tyler_lower_court_code": "1755",
     "name": "Charlestown Division, Boston Municipal Court",
     "phone": "(617) 242-5400",
     "has_po_box": false,
@@ -65,7 +65,7 @@
   {
     "fax": "(617) 436-8250 ",
     "court_code": "07",
-    "lower_court_code": "1756",
+    "tyler_lower_court_code": "1756",
     "name": "Dorchester Division, Boston Municipal Court",
     "phone": "(617) 288-9500",
     "has_po_box": false,
@@ -86,7 +86,7 @@
   {
     "fax": "(617) 561-4988 ",
     "court_code": "05",
-    "lower_court_code": "1757",
+    "tyler_lower_court_code": "1757",
     "name": "East Boston Division, Boston Municipal Court",
     "phone": "(617) 569-7550",
     "has_po_box": false,
@@ -107,7 +107,7 @@
   {
     "fax": "(617) 541-0286",
     "court_code": "02",
-    "lower_court_code": "1758",
+    "tyler_lower_court_code": "1758",
     "name": "Roxbury Division, Boston Municipal Court",
     "phone": "(617) 427-7000",
     "has_po_box": false,
@@ -128,7 +128,7 @@
   {
     "fax": "(617) 983-0243 ",
     "court_code": "06",
-    "lower_court_code": "1760",
+    "tyler_lower_court_code": "1760",
     "name": "West Roxbury Division, Boston Municipal Court",
     "phone": "(617) 971-1200",
     "has_po_box": false,
@@ -149,7 +149,7 @@
   {
     "fax": "(617) 268-7321",
     "court_code": "03",
-    "lower_court_code": "1759",
+    "tyler_lower_court_code": "1759",
     "name": "South Boston Division, Boston Municipal Court",
     "phone": "(617) 268-9292",
     "has_po_box": false,

--- a/docassemble/MACourts/data/sources/bmc.json
+++ b/docassemble/MACourts/data/sources/bmc.json
@@ -2,6 +2,7 @@
   {
     "fax": "(617) 254-2127",
     "court_code": "08",
+    "lower_court_code": "1753",
     "name": "Brighton Division, Boston Municipal Court",
     "phone": "(617) 782-6540, Press 5",
     "has_po_box": false,
@@ -17,12 +18,12 @@
       "state": "MA",
       "address": "52 Academy Hill Rd."
     },
-    "description": "The Brighton division of the BMC serves Allston and Brighton. Please note that as of March 1, the Brighton Division of the Boston Municipal Court has temporarily relocated to Brookline District Court while the Brighton courthouse undergoes renovations. ",
-    "lower_court_code": "1753"
+    "description": "The Brighton division of the BMC serves Allston and Brighton. Please note that as of March 1, the Brighton Division of the Boston Municipal Court has temporarily relocated to Brookline District Court while the Brighton courthouse undergoes renovations. "
   },
   {
     "fax": "(617) 788-8465",
     "court_code": "01",
+    "lower_court_code": "1754",
     "name": "Central Division, Boston Municipal Court",
     "phone": "(617) 788-8600",
     "has_po_box": false,
@@ -38,12 +39,12 @@
       "state": "MA",
       "address": "24 New Chardon Street"
     },
-    "description": "This court serves the Downtown Boston area, Chinatown, North End, South End through Massachusetts Avenue, West End, and Beacon Hill.",
-    "lower_court_code": "1754"
+    "description": "This court serves the Downtown Boston area, Chinatown, North End, South End through Massachusetts Avenue, West End, and Beacon Hill."
   },
   {
     "fax": "(617) 242-1677",
     "court_code": "04",
+    "lower_court_code": "1755",
     "name": "Charlestown Division, Boston Municipal Court",
     "phone": "(617) 242-5400",
     "has_po_box": false,
@@ -59,12 +60,12 @@
       "state": "MA",
       "address": "3 City Square"
     },
-    "description": "The Charlestown Division of the Boston Municipal Court serves Charlestown.",
-    "lower_court_code": "1755"
+    "description": "The Charlestown Division of the Boston Municipal Court serves Charlestown."
   },
   {
     "fax": "(617) 436-8250 ",
     "court_code": "07",
+    "lower_court_code": "1756",
     "name": "Dorchester Division, Boston Municipal Court",
     "phone": "(617) 288-9500",
     "has_po_box": false,
@@ -80,12 +81,12 @@
       "state": "MA",
       "address": "510 Washington St."
     },
-    "description": "This court serves Dorchester.",
-    "lower_court_code": "1756"
+    "description": "This court serves Dorchester."
   },
   {
     "fax": "(617) 561-4988 ",
     "court_code": "05",
+    "lower_court_code": "1757",
     "name": "East Boston Division, Boston Municipal Court",
     "phone": "(617) 569-7550",
     "has_po_box": false,
@@ -101,12 +102,12 @@
       "state": "MA",
       "address": "37 Meridian St."
     },
-    "description": "This court serves East Boston, Winthrop, Logan Airport, and the Sumner and Callahan Tunnels.",
-    "lower_court_code": "1757"
+    "description": "This court serves East Boston, Winthrop, Logan Airport, and the Sumner and Callahan Tunnels."
   },
   {
     "fax": "(617) 541-0286",
     "court_code": "02",
+    "lower_court_code": "1758",
     "name": "Roxbury Division, Boston Municipal Court",
     "phone": "(617) 427-7000",
     "has_po_box": false,
@@ -122,12 +123,12 @@
       "state": "MA",
       "address": "85 Warren St."
     },
-    "description": "This court serves Roxbury.",
-    "lower_court_code": "1758"
+    "description": "This court serves Roxbury."
   },
   {
     "fax": "(617) 983-0243 ",
     "court_code": "06",
+    "lower_court_code": "1760",
     "name": "West Roxbury Division, Boston Municipal Court",
     "phone": "(617) 971-1200",
     "has_po_box": false,
@@ -143,12 +144,12 @@
       "state": "MA",
       "address": "445 Arborway"
     },
-    "description": "This court serves Hyde Park, Jamaica Plain, Roslindale, West Roxbury, parts of Mattapan, and parts of Mission Hill.",
-    "lower_court_code": "1760"
+    "description": "This court serves Hyde Park, Jamaica Plain, Roslindale, West Roxbury, parts of Mattapan, and parts of Mission Hill."
   },
   {
     "fax": "(617) 268-7321",
     "court_code": "03",
+    "lower_court_code": "1759",
     "name": "South Boston Division, Boston Municipal Court",
     "phone": "(617) 268-9292",
     "has_po_box": false,
@@ -164,7 +165,6 @@
       "state": "MA",
       "address": "535 East Broadway"
     },
-    "description": "This court serves South Boston.",
-    "lower_court_code": "1759"
+    "description": "This court serves South Boston."
   }
 ]

--- a/docassemble/MACourts/data/sources/district_courts.json
+++ b/docassemble/MACourts/data/sources/district_courts.json
@@ -2,6 +2,7 @@
   {
     "fax": "",
     "court_code": "34",
+    "lower_court_code": "1764",
     "name": "Attleboro District Court",
     "phone": "(508) 222-5900 ",
     "has_po_box": false,
@@ -22,6 +23,7 @@
   {
     "fax": "(978) 772-5345",
     "court_code": "48",
+    "lower_court_code": "1765",
     "name": "Ayer District Court",
     "phone": "(978) 772-2100",
     "has_po_box": false,
@@ -42,6 +44,7 @@
   {
     "fax": "",
     "court_code": "25",
+    "lower_court_code": "1766",
     "name": "Barnstable District Court",
     "phone": "(508) 375-6778",
     "has_po_box": true,
@@ -62,6 +65,7 @@
   {
     "fax": "(508) 587-6791",
     "court_code": "15",
+    "lower_court_code": "1767",
     "name": "Brockton District Court",
     "phone": "(508) 587-8000",
     "has_po_box": false,
@@ -82,6 +86,7 @@
   {
     "fax": "",
     "court_code": "09",
+    "lower_court_code": "1768",
     "name": "Brookline District Court",
     "phone": "(617) 232-4660",
     "has_po_box": false,
@@ -102,6 +107,7 @@
   {
     "fax": "(781) 395-2035",
     "court_code": "52",
+    "lower_court_code": "1769",
     "name": "Cambridge District Court",
     "phone": "(781) 306-2715",
     "has_po_box": false,
@@ -122,6 +128,7 @@
   {
     "fax": "(617) 660-9215",
     "court_code": "14",
+    "lower_court_code": "1770",
     "name": "Chelsea District Court",
     "phone": "(617) 660-9200",
     "has_po_box": false,
@@ -142,6 +149,7 @@
   {
     "fax": "(413) 594-6187",
     "court_code": "20",
+    "lower_court_code": "1771",
     "name": "Chicopee District Court",
     "phone": "(413) 598-0099",
     "has_po_box": false,
@@ -162,6 +170,7 @@
   {
     "fax": "(978) 368-7827",
     "court_code": "68",
+    "lower_court_code": "1772",
     "name": "Clinton District Court",
     "phone": "(978) 368-7811",
     "has_po_box": false,
@@ -182,6 +191,7 @@
   {
     "fax": "(978) 371-2945",
     "court_code": "47",
+    "lower_court_code": "1773",
     "name": "Concord District Court",
     "phone": "(978) 369-0500",
     "has_po_box": false,
@@ -202,6 +212,7 @@
   {
     "fax": "",
     "court_code": "54",
+    "lower_court_code": "1774",
     "name": "Dedham District Court",
     "phone": "(781) 329-4777",
     "has_po_box": false,
@@ -222,6 +233,7 @@
   {
     "fax": "",
     "court_code": "64",
+    "lower_court_code": "1775",
     "name": "Dudley District Court",
     "phone": "(508) 943-7123",
     "has_po_box": false,
@@ -242,6 +254,7 @@
   {
     "fax": "(508) 885-7623",
     "court_code": "69",
+    "lower_court_code": "1776",
     "name": "East Brookfield District Court",
     "phone": "(508) 885-6305",
     "has_po_box": false,
@@ -262,6 +275,7 @@
   {
     "fax": "(413) 323-6803",
     "court_code": "98",
+    "lower_court_code": "1777",
     "name": "Eastern Hampshire District Court",
     "phone": "(413) 323-4056",
     "has_po_box": false,
@@ -283,6 +297,7 @@
   {
     "fax": "",
     "court_code": "35",
+    "lower_court_code": "1778",
     "name": "Edgartown District Court",
     "phone": "",
     "has_po_box": false,
@@ -303,6 +318,7 @@
   {
     "fax": "",
     "court_code": "32",
+    "lower_court_code": "1779",
     "name": "Fall River District Court",
     "phone": "",
     "has_po_box": false,
@@ -324,6 +340,7 @@
   {
     "fax": "",
     "court_code": "89",
+    "lower_court_code": "1780",
     "name": "Falmouth District Court",
     "phone": "(508) 495-1500",
     "has_po_box": false,
@@ -344,6 +361,7 @@
   {
     "fax": "(978) 342-2461",
     "court_code": "16",
+    "lower_court_code": "1781",
     "name": "Fitchburg District Court",
     "phone": "(978) 345-2111",
     "has_po_box": false,
@@ -364,6 +382,7 @@
   {
     "fax": "",
     "court_code": "49",
+    "lower_court_code": "1782",
     "name": "Framingham District Court",
     "phone": "(508) 875-7461",
     "has_po_box": false,
@@ -384,6 +403,7 @@
   {
     "fax": "(978) 630-3902",
     "court_code": "63",
+    "lower_court_code": "1783",
     "name": "Gardner District Court",
     "phone": "(978) 632-2373",
     "has_po_box": false,
@@ -404,6 +424,7 @@
   {
     "fax": "(978) 283-8784",
     "court_code": "39",
+    "lower_court_code": "1784",
     "name": "Gloucester District Court",
     "phone": "(978) 283-2620",
     "has_po_box": false,
@@ -424,6 +445,7 @@
   {
     "fax": "(413) 774-5328",
     "court_code": "41",
+    "lower_court_code": "1785",
     "name": "Greenfield District Court",
     "phone": "(413) 774-5533",
     "has_po_box": false,
@@ -444,6 +466,7 @@
   {
     "fax": "",
     "court_code": "38",
+    "lower_court_code": "1786",
     "name": "Haverhill District Court",
     "phone": "(978) 521-7300",
     "has_po_box": false,
@@ -464,6 +487,7 @@
   {
     "fax": "(781) 740-8390",
     "court_code": "58",
+    "lower_court_code": "1787",
     "name": "Hingham District Court",
     "phone": "(781) 749-7000",
     "has_po_box": false,
@@ -484,6 +508,7 @@
   {
     "fax": "(413) 533-7165",
     "court_code": "17",
+    "lower_court_code": "1788",
     "name": "Holyoke District Court",
     "phone": "(413) 538-9710",
     "has_po_box": false,
@@ -504,6 +529,7 @@
   {
     "fax": "(978) 462-5641",
     "court_code": "40",
+    "lower_court_code": "1789",
     "name": "Ipswich District Court",
     "phone": "(978) 462-2652",
     "has_po_box": false,
@@ -524,6 +550,7 @@
   {
     "fax": "",
     "court_code": "18",
+    "lower_court_code": "1790",
     "name": "Lawrence District Court",
     "phone": "(978) 687-7184",
     "has_po_box": false,
@@ -545,6 +572,7 @@
   {
     "fax": "(978) 537-3970",
     "court_code": "61",
+    "lower_court_code": "1791",
     "name": "Leominster District Court",
     "phone": "(978) 537-3722",
     "has_po_box": false,
@@ -565,6 +593,7 @@
   {
     "fax": "(978) 937-2486",
     "court_code": "11",
+    "lower_court_code": "1792",
     "name": "Lowell District Court",
     "phone": "(978) 459-4101",
     "has_po_box": false,
@@ -585,6 +614,7 @@
   {
     "fax": "(781) 598-4350",
     "court_code": "13",
+    "lower_court_code": "1793",
     "name": "Lynn District Court",
     "phone": "(781) 598-5200",
     "has_po_box": false,
@@ -605,6 +635,7 @@
   {
     "fax": "(781) 322-0169",
     "court_code": "50",
+    "lower_court_code": "1794",
     "name": "Malden District Court",
     "phone": "(781) 322-7500",
     "has_po_box": false,
@@ -625,6 +656,7 @@
   {
     "fax": "(508) 485-1575",
     "court_code": "21",
+    "lower_court_code": "1795",
     "name": "Marlborough District Court",
     "phone": "(508) 485-3700",
     "has_po_box": false,
@@ -645,6 +677,7 @@
   {
     "fax": "(508) 634-8477",
     "court_code": "66",
+    "lower_court_code": "1796",
     "name": "Milford District Court",
     "phone": "(508) 473-1260",
     "has_po_box": false,
@@ -665,6 +698,7 @@
   {
     "fax": "(508) 325-5759",
     "court_code": "88",
+    "lower_court_code": "1797",
     "name": "Nantucket District Court",
     "phone": "(508) 228-0460",
     "has_po_box": false,
@@ -685,6 +719,7 @@
   {
     "fax": "(508) 990-8094 ",
     "court_code": "33",
+    "lower_court_code": "1799",
     "name": "New Bedford District Court",
     "phone": "(508) 999-9700",
     "has_po_box": false,
@@ -705,6 +740,7 @@
   {
     "fax": "(978) 465-6471",
     "court_code": "22",
+    "lower_court_code": "1800",
     "name": "Newburyport District Court",
     "phone": "(978) 462-2652",
     "has_po_box": false,
@@ -725,6 +761,7 @@
   {
     "fax": "(617) 243-7291",
     "court_code": "12",
+    "lower_court_code": "1801",
     "name": "Newton District Court",
     "phone": "(617) 244-3600",
     "has_po_box": false,
@@ -745,6 +782,7 @@
   {
     "fax": "(413) 586-1980",
     "court_code": "45",
+    "lower_court_code": "1802",
     "name": "Northampton District Court",
     "phone": "(413) 584-7400",
     "has_po_box": false,
@@ -765,6 +803,7 @@
   {
     "fax": "(413) 664-7209",
     "court_code": "28",
+    "lower_court_code": "1803",
     "name": "Northern Berkshire District Court",
     "phone": "(413) 663-5339",
     "has_po_box": false,
@@ -785,6 +824,7 @@
   {
     "fax": "(978) 544-5204",
     "court_code": "42",
+    "lower_court_code": "1804",
     "name": "Orange District Court",
     "phone": "(978) 544-8277",
     "has_po_box": false,
@@ -805,6 +845,7 @@
   {
     "fax": "(508) 240-1150",
     "court_code": "26",
+    "lower_court_code": "1805",
     "name": "Orleans District Court",
     "phone": "(508) 255-4700",
     "has_po_box": false,
@@ -825,6 +866,7 @@
   {
     "fax": "(413) 283-6775",
     "court_code": "43",
+    "lower_court_code": "1806",
     "name": "Palmer District Court",
     "phone": "(413) 283-8916",
     "has_po_box": false,
@@ -846,6 +888,7 @@
   {
     "fax": "(978) 531-8524",
     "court_code": "86",
+    "lower_court_code": "1807",
     "name": "Peabody District Court",
     "phone": "(978) 532-3100",
     "has_po_box": false,
@@ -866,6 +909,7 @@
   {
     "fax": "(413) 499-7327",
     "court_code": "27",
+    "lower_court_code": "1808",
     "name": "Pittsfield District Court",
     "phone": "(413) 499-0558",
     "has_po_box": true,
@@ -886,6 +930,7 @@
   {
     "fax": "(508) 830-9303",
     "court_code": "59",
+    "lower_court_code": "1809",
     "name": "Plymouth District Court",
     "phone": "(508) 747-8400",
     "has_po_box": false,
@@ -906,6 +951,7 @@
   {
     "fax": "(617) 472-1924",
     "court_code": "56",
+    "lower_court_code": "1810",
     "name": "Quincy District Court",
     "phone": "(617) 471-1650",
     "has_po_box": false,
@@ -926,6 +972,7 @@
   {
     "fax": "",
     "court_code": "36",
+    "lower_court_code": "1811",
     "name": "Salem District Court",
     "phone": "(978) 744-1167",
     "has_po_box": false,
@@ -946,6 +993,7 @@
   {
     "fax": "(617) 776-2111",
     "court_code": "10",
+    "lower_court_code": "1812",
     "name": "Somerville District Court",
     "phone": "(617) 666-8000",
     "has_po_box": false,
@@ -966,6 +1014,7 @@
   {
     "fax": "(413) 528-0757",
     "court_code": "29",
+    "lower_court_code": "1813",
     "name": "Southern Berkshire District Court",
     "phone": "(413) 528-3520",
     "has_po_box": false,
@@ -986,6 +1035,7 @@
   {
     "fax": "",
     "court_code": "23",
+    "lower_court_code": "1814",
     "name": "Springfield District Court",
     "phone": "(413) 748-8600",
     "has_po_box": true,
@@ -1006,6 +1056,7 @@
   {
     "fax": "(781) 341-8744",
     "court_code": "55",
+    "lower_court_code": "1815",
     "name": "Stoughton District Court",
     "phone": "(781) 344-2131",
     "has_po_box": false,
@@ -1026,6 +1077,7 @@
   {
     "fax": "(508) 824-2282",
     "court_code": "31",
+    "lower_court_code": "1816",
     "name": "Taunton District Court",
     "phone": "(508) 977-6000",
     "has_po_box": false,
@@ -1046,6 +1098,7 @@
   {
     "fax": "(508) 278-2929",
     "court_code": "65",
+    "lower_court_code": "1817",
     "name": "Uxbridge District Court",
     "phone": "(508) 278-2454",
     "has_po_box": false,
@@ -1066,6 +1119,7 @@
   {
     "fax": "",
     "court_code": "51",
+    "lower_court_code": "1818",
     "name": "Waltham District Court",
     "phone": "(781) 894-4500",
     "has_po_box": false,
@@ -1086,6 +1140,7 @@
   {
     "fax": "(508) 291-6376",
     "court_code": "60",
+    "lower_court_code": "1819",
     "name": "Wareham District Court",
     "phone": "(508) 295-8300",
     "has_po_box": false,
@@ -1106,6 +1161,7 @@
   {
     "fax": "(508) 366-8268",
     "court_code": "67",
+    "lower_court_code": "1820",
     "name": "Westborough District Court",
     "phone": "(508) 366-8266",
     "has_po_box": false,
@@ -1126,6 +1182,7 @@
   {
     "fax": "(413) 568-4863",
     "court_code": "44",
+    "lower_court_code": "1821",
     "name": "Westfield District Court",
     "phone": "(413) 568-8946",
     "has_po_box": false,
@@ -1146,6 +1203,7 @@
   {
     "fax": "(978) 632-3580",
     "court_code": "70",
+    "lower_court_code": "1822",
     "name": "Winchendon District Court",
     "phone": "(978) 632-6326",
     "has_po_box": false,
@@ -1166,6 +1224,7 @@
   {
     "fax": "(781) 933-4404",
     "court_code": "53",
+    "lower_court_code": "1823",
     "name": "Woburn District Court",
     "phone": "(781) 935-4000",
     "has_po_box": false,
@@ -1186,6 +1245,7 @@
   {
     "fax": "",
     "court_code": "62",
+    "lower_court_code": "1824",
     "name": "Worcester District Court",
     "phone": "(508) 831-2010",
     "has_po_box": false,
@@ -1206,6 +1266,7 @@
   {
     "fax": "",
     "court_code": "57",
+    "lower_court_code": "1825",
     "name": "Wrentham District Court",
     "phone": "(508) 384-3106",
     "has_po_box": false,

--- a/docassemble/MACourts/data/sources/district_courts.json
+++ b/docassemble/MACourts/data/sources/district_courts.json
@@ -2,7 +2,7 @@
   {
     "fax": "",
     "court_code": "34",
-    "lower_court_code": "1764",
+    "tyler_lower_court_code": "1764",
     "name": "Attleboro District Court",
     "phone": "(508) 222-5900 ",
     "has_po_box": false,
@@ -23,7 +23,7 @@
   {
     "fax": "(978) 772-5345",
     "court_code": "48",
-    "lower_court_code": "1765",
+    "tyler_lower_court_code": "1765",
     "name": "Ayer District Court",
     "phone": "(978) 772-2100",
     "has_po_box": false,
@@ -44,7 +44,7 @@
   {
     "fax": "",
     "court_code": "25",
-    "lower_court_code": "1766",
+    "tyler_lower_court_code": "1766",
     "name": "Barnstable District Court",
     "phone": "(508) 375-6778",
     "has_po_box": true,
@@ -65,7 +65,7 @@
   {
     "fax": "(508) 587-6791",
     "court_code": "15",
-    "lower_court_code": "1767",
+    "tyler_lower_court_code": "1767",
     "name": "Brockton District Court",
     "phone": "(508) 587-8000",
     "has_po_box": false,
@@ -86,7 +86,7 @@
   {
     "fax": "",
     "court_code": "09",
-    "lower_court_code": "1768",
+    "tyler_lower_court_code": "1768",
     "name": "Brookline District Court",
     "phone": "(617) 232-4660",
     "has_po_box": false,
@@ -107,7 +107,7 @@
   {
     "fax": "(781) 395-2035",
     "court_code": "52",
-    "lower_court_code": "1769",
+    "tyler_lower_court_code": "1769",
     "name": "Cambridge District Court",
     "phone": "(781) 306-2715",
     "has_po_box": false,
@@ -128,7 +128,7 @@
   {
     "fax": "(617) 660-9215",
     "court_code": "14",
-    "lower_court_code": "1770",
+    "tyler_lower_court_code": "1770",
     "name": "Chelsea District Court",
     "phone": "(617) 660-9200",
     "has_po_box": false,
@@ -149,7 +149,7 @@
   {
     "fax": "(413) 594-6187",
     "court_code": "20",
-    "lower_court_code": "1771",
+    "tyler_lower_court_code": "1771",
     "name": "Chicopee District Court",
     "phone": "(413) 598-0099",
     "has_po_box": false,
@@ -170,7 +170,7 @@
   {
     "fax": "(978) 368-7827",
     "court_code": "68",
-    "lower_court_code": "1772",
+    "tyler_lower_court_code": "1772",
     "name": "Clinton District Court",
     "phone": "(978) 368-7811",
     "has_po_box": false,
@@ -191,7 +191,7 @@
   {
     "fax": "(978) 371-2945",
     "court_code": "47",
-    "lower_court_code": "1773",
+    "tyler_lower_court_code": "1773",
     "name": "Concord District Court",
     "phone": "(978) 369-0500",
     "has_po_box": false,
@@ -212,7 +212,7 @@
   {
     "fax": "",
     "court_code": "54",
-    "lower_court_code": "1774",
+    "tyler_lower_court_code": "1774",
     "name": "Dedham District Court",
     "phone": "(781) 329-4777",
     "has_po_box": false,
@@ -233,7 +233,7 @@
   {
     "fax": "",
     "court_code": "64",
-    "lower_court_code": "1775",
+    "tyler_lower_court_code": "1775",
     "name": "Dudley District Court",
     "phone": "(508) 943-7123",
     "has_po_box": false,
@@ -254,7 +254,7 @@
   {
     "fax": "(508) 885-7623",
     "court_code": "69",
-    "lower_court_code": "1776",
+    "tyler_lower_court_code": "1776",
     "name": "East Brookfield District Court",
     "phone": "(508) 885-6305",
     "has_po_box": false,
@@ -275,7 +275,7 @@
   {
     "fax": "(413) 323-6803",
     "court_code": "98",
-    "lower_court_code": "1777",
+    "tyler_lower_court_code": "1777",
     "name": "Eastern Hampshire District Court",
     "phone": "(413) 323-4056",
     "has_po_box": false,
@@ -297,7 +297,7 @@
   {
     "fax": "",
     "court_code": "35",
-    "lower_court_code": "1778",
+    "tyler_lower_court_code": "1778",
     "name": "Edgartown District Court",
     "phone": "",
     "has_po_box": false,
@@ -318,7 +318,7 @@
   {
     "fax": "",
     "court_code": "32",
-    "lower_court_code": "1779",
+    "tyler_lower_court_code": "1779",
     "name": "Fall River District Court",
     "phone": "",
     "has_po_box": false,
@@ -340,7 +340,7 @@
   {
     "fax": "",
     "court_code": "89",
-    "lower_court_code": "1780",
+    "tyler_lower_court_code": "1780",
     "name": "Falmouth District Court",
     "phone": "(508) 495-1500",
     "has_po_box": false,
@@ -361,7 +361,7 @@
   {
     "fax": "(978) 342-2461",
     "court_code": "16",
-    "lower_court_code": "1781",
+    "tyler_lower_court_code": "1781",
     "name": "Fitchburg District Court",
     "phone": "(978) 345-2111",
     "has_po_box": false,
@@ -382,7 +382,7 @@
   {
     "fax": "",
     "court_code": "49",
-    "lower_court_code": "1782",
+    "tyler_lower_court_code": "1782",
     "name": "Framingham District Court",
     "phone": "(508) 875-7461",
     "has_po_box": false,
@@ -403,7 +403,7 @@
   {
     "fax": "(978) 630-3902",
     "court_code": "63",
-    "lower_court_code": "1783",
+    "tyler_lower_court_code": "1783",
     "name": "Gardner District Court",
     "phone": "(978) 632-2373",
     "has_po_box": false,
@@ -424,7 +424,7 @@
   {
     "fax": "(978) 283-8784",
     "court_code": "39",
-    "lower_court_code": "1784",
+    "tyler_lower_court_code": "1784",
     "name": "Gloucester District Court",
     "phone": "(978) 283-2620",
     "has_po_box": false,
@@ -445,7 +445,7 @@
   {
     "fax": "(413) 774-5328",
     "court_code": "41",
-    "lower_court_code": "1785",
+    "tyler_lower_court_code": "1785",
     "name": "Greenfield District Court",
     "phone": "(413) 774-5533",
     "has_po_box": false,
@@ -466,7 +466,7 @@
   {
     "fax": "",
     "court_code": "38",
-    "lower_court_code": "1786",
+    "tyler_lower_court_code": "1786",
     "name": "Haverhill District Court",
     "phone": "(978) 521-7300",
     "has_po_box": false,
@@ -487,7 +487,7 @@
   {
     "fax": "(781) 740-8390",
     "court_code": "58",
-    "lower_court_code": "1787",
+    "tyler_lower_court_code": "1787",
     "name": "Hingham District Court",
     "phone": "(781) 749-7000",
     "has_po_box": false,
@@ -508,7 +508,7 @@
   {
     "fax": "(413) 533-7165",
     "court_code": "17",
-    "lower_court_code": "1788",
+    "tyler_lower_court_code": "1788",
     "name": "Holyoke District Court",
     "phone": "(413) 538-9710",
     "has_po_box": false,
@@ -529,7 +529,7 @@
   {
     "fax": "(978) 462-5641",
     "court_code": "40",
-    "lower_court_code": "1789",
+    "tyler_lower_court_code": "1789",
     "name": "Ipswich District Court",
     "phone": "(978) 462-2652",
     "has_po_box": false,
@@ -550,7 +550,7 @@
   {
     "fax": "",
     "court_code": "18",
-    "lower_court_code": "1790",
+    "tyler_lower_court_code": "1790",
     "name": "Lawrence District Court",
     "phone": "(978) 687-7184",
     "has_po_box": false,
@@ -572,7 +572,7 @@
   {
     "fax": "(978) 537-3970",
     "court_code": "61",
-    "lower_court_code": "1791",
+    "tyler_lower_court_code": "1791",
     "name": "Leominster District Court",
     "phone": "(978) 537-3722",
     "has_po_box": false,
@@ -593,7 +593,7 @@
   {
     "fax": "(978) 937-2486",
     "court_code": "11",
-    "lower_court_code": "1792",
+    "tyler_lower_court_code": "1792",
     "name": "Lowell District Court",
     "phone": "(978) 459-4101",
     "has_po_box": false,
@@ -614,7 +614,7 @@
   {
     "fax": "(781) 598-4350",
     "court_code": "13",
-    "lower_court_code": "1793",
+    "tyler_lower_court_code": "1793",
     "name": "Lynn District Court",
     "phone": "(781) 598-5200",
     "has_po_box": false,
@@ -635,7 +635,7 @@
   {
     "fax": "(781) 322-0169",
     "court_code": "50",
-    "lower_court_code": "1794",
+    "tyler_lower_court_code": "1794",
     "name": "Malden District Court",
     "phone": "(781) 322-7500",
     "has_po_box": false,
@@ -656,7 +656,7 @@
   {
     "fax": "(508) 485-1575",
     "court_code": "21",
-    "lower_court_code": "1795",
+    "tyler_lower_court_code": "1795",
     "name": "Marlborough District Court",
     "phone": "(508) 485-3700",
     "has_po_box": false,
@@ -677,7 +677,7 @@
   {
     "fax": "(508) 634-8477",
     "court_code": "66",
-    "lower_court_code": "1796",
+    "tyler_lower_court_code": "1796",
     "name": "Milford District Court",
     "phone": "(508) 473-1260",
     "has_po_box": false,
@@ -698,7 +698,7 @@
   {
     "fax": "(508) 325-5759",
     "court_code": "88",
-    "lower_court_code": "1797",
+    "tyler_lower_court_code": "1797",
     "name": "Nantucket District Court",
     "phone": "(508) 228-0460",
     "has_po_box": false,
@@ -719,7 +719,7 @@
   {
     "fax": "(508) 990-8094 ",
     "court_code": "33",
-    "lower_court_code": "1799",
+    "tyler_lower_court_code": "1799",
     "name": "New Bedford District Court",
     "phone": "(508) 999-9700",
     "has_po_box": false,
@@ -740,7 +740,7 @@
   {
     "fax": "(978) 465-6471",
     "court_code": "22",
-    "lower_court_code": "1800",
+    "tyler_lower_court_code": "1800",
     "name": "Newburyport District Court",
     "phone": "(978) 462-2652",
     "has_po_box": false,
@@ -761,7 +761,7 @@
   {
     "fax": "(617) 243-7291",
     "court_code": "12",
-    "lower_court_code": "1801",
+    "tyler_lower_court_code": "1801",
     "name": "Newton District Court",
     "phone": "(617) 244-3600",
     "has_po_box": false,
@@ -782,7 +782,7 @@
   {
     "fax": "(413) 586-1980",
     "court_code": "45",
-    "lower_court_code": "1802",
+    "tyler_lower_court_code": "1802",
     "name": "Northampton District Court",
     "phone": "(413) 584-7400",
     "has_po_box": false,
@@ -803,7 +803,7 @@
   {
     "fax": "(413) 664-7209",
     "court_code": "28",
-    "lower_court_code": "1803",
+    "tyler_lower_court_code": "1803",
     "name": "Northern Berkshire District Court",
     "phone": "(413) 663-5339",
     "has_po_box": false,
@@ -824,7 +824,7 @@
   {
     "fax": "(978) 544-5204",
     "court_code": "42",
-    "lower_court_code": "1804",
+    "tyler_lower_court_code": "1804",
     "name": "Orange District Court",
     "phone": "(978) 544-8277",
     "has_po_box": false,
@@ -845,7 +845,7 @@
   {
     "fax": "(508) 240-1150",
     "court_code": "26",
-    "lower_court_code": "1805",
+    "tyler_lower_court_code": "1805",
     "name": "Orleans District Court",
     "phone": "(508) 255-4700",
     "has_po_box": false,
@@ -866,7 +866,7 @@
   {
     "fax": "(413) 283-6775",
     "court_code": "43",
-    "lower_court_code": "1806",
+    "tyler_lower_court_code": "1806",
     "name": "Palmer District Court",
     "phone": "(413) 283-8916",
     "has_po_box": false,
@@ -888,7 +888,7 @@
   {
     "fax": "(978) 531-8524",
     "court_code": "86",
-    "lower_court_code": "1807",
+    "tyler_lower_court_code": "1807",
     "name": "Peabody District Court",
     "phone": "(978) 532-3100",
     "has_po_box": false,
@@ -909,7 +909,7 @@
   {
     "fax": "(413) 499-7327",
     "court_code": "27",
-    "lower_court_code": "1808",
+    "tyler_lower_court_code": "1808",
     "name": "Pittsfield District Court",
     "phone": "(413) 499-0558",
     "has_po_box": true,
@@ -930,7 +930,7 @@
   {
     "fax": "(508) 830-9303",
     "court_code": "59",
-    "lower_court_code": "1809",
+    "tyler_lower_court_code": "1809",
     "name": "Plymouth District Court",
     "phone": "(508) 747-8400",
     "has_po_box": false,
@@ -951,7 +951,7 @@
   {
     "fax": "(617) 472-1924",
     "court_code": "56",
-    "lower_court_code": "1810",
+    "tyler_lower_court_code": "1810",
     "name": "Quincy District Court",
     "phone": "(617) 471-1650",
     "has_po_box": false,
@@ -972,7 +972,7 @@
   {
     "fax": "",
     "court_code": "36",
-    "lower_court_code": "1811",
+    "tyler_lower_court_code": "1811",
     "name": "Salem District Court",
     "phone": "(978) 744-1167",
     "has_po_box": false,
@@ -993,7 +993,7 @@
   {
     "fax": "(617) 776-2111",
     "court_code": "10",
-    "lower_court_code": "1812",
+    "tyler_lower_court_code": "1812",
     "name": "Somerville District Court",
     "phone": "(617) 666-8000",
     "has_po_box": false,
@@ -1014,7 +1014,7 @@
   {
     "fax": "(413) 528-0757",
     "court_code": "29",
-    "lower_court_code": "1813",
+    "tyler_lower_court_code": "1813",
     "name": "Southern Berkshire District Court",
     "phone": "(413) 528-3520",
     "has_po_box": false,
@@ -1035,7 +1035,7 @@
   {
     "fax": "",
     "court_code": "23",
-    "lower_court_code": "1814",
+    "tyler_lower_court_code": "1814",
     "name": "Springfield District Court",
     "phone": "(413) 748-8600",
     "has_po_box": true,
@@ -1056,7 +1056,7 @@
   {
     "fax": "(781) 341-8744",
     "court_code": "55",
-    "lower_court_code": "1815",
+    "tyler_lower_court_code": "1815",
     "name": "Stoughton District Court",
     "phone": "(781) 344-2131",
     "has_po_box": false,
@@ -1077,7 +1077,7 @@
   {
     "fax": "(508) 824-2282",
     "court_code": "31",
-    "lower_court_code": "1816",
+    "tyler_lower_court_code": "1816",
     "name": "Taunton District Court",
     "phone": "(508) 977-6000",
     "has_po_box": false,
@@ -1098,7 +1098,7 @@
   {
     "fax": "(508) 278-2929",
     "court_code": "65",
-    "lower_court_code": "1817",
+    "tyler_lower_court_code": "1817",
     "name": "Uxbridge District Court",
     "phone": "(508) 278-2454",
     "has_po_box": false,
@@ -1119,7 +1119,7 @@
   {
     "fax": "",
     "court_code": "51",
-    "lower_court_code": "1818",
+    "tyler_lower_court_code": "1818",
     "name": "Waltham District Court",
     "phone": "(781) 894-4500",
     "has_po_box": false,
@@ -1140,7 +1140,7 @@
   {
     "fax": "(508) 291-6376",
     "court_code": "60",
-    "lower_court_code": "1819",
+    "tyler_lower_court_code": "1819",
     "name": "Wareham District Court",
     "phone": "(508) 295-8300",
     "has_po_box": false,
@@ -1161,7 +1161,7 @@
   {
     "fax": "(508) 366-8268",
     "court_code": "67",
-    "lower_court_code": "1820",
+    "tyler_lower_court_code": "1820",
     "name": "Westborough District Court",
     "phone": "(508) 366-8266",
     "has_po_box": false,
@@ -1182,7 +1182,7 @@
   {
     "fax": "(413) 568-4863",
     "court_code": "44",
-    "lower_court_code": "1821",
+    "tyler_lower_court_code": "1821",
     "name": "Westfield District Court",
     "phone": "(413) 568-8946",
     "has_po_box": false,
@@ -1203,7 +1203,7 @@
   {
     "fax": "(978) 632-3580",
     "court_code": "70",
-    "lower_court_code": "1822",
+    "tyler_lower_court_code": "1822",
     "name": "Winchendon District Court",
     "phone": "(978) 632-6326",
     "has_po_box": false,
@@ -1224,7 +1224,7 @@
   {
     "fax": "(781) 933-4404",
     "court_code": "53",
-    "lower_court_code": "1823",
+    "tyler_lower_court_code": "1823",
     "name": "Woburn District Court",
     "phone": "(781) 935-4000",
     "has_po_box": false,
@@ -1245,7 +1245,7 @@
   {
     "fax": "",
     "court_code": "62",
-    "lower_court_code": "1824",
+    "tyler_lower_court_code": "1824",
     "name": "Worcester District Court",
     "phone": "(508) 831-2010",
     "has_po_box": false,
@@ -1266,7 +1266,7 @@
   {
     "fax": "",
     "court_code": "57",
-    "lower_court_code": "1825",
+    "tyler_lower_court_code": "1825",
     "name": "Wrentham District Court",
     "phone": "(508) 384-3106",
     "has_po_box": false,

--- a/docassemble/MACourts/data/sources/housing_courts.json
+++ b/docassemble/MACourts/data/sources/housing_courts.json
@@ -17,7 +17,9 @@
       "address": "279 West Main St."
     },
     "description": "The Dudley session of the Central Division of the Housing Court serves Charlton, Dudley, Oxford, Southbridge, Sturbridge, and Webster",
-    "court_code": "H85"
+    "court_code": "H85",
+    "tyler_code": "535",
+    "lower_court_code": "1831"
   },
   {
     "fax": "",
@@ -37,7 +39,9 @@
       "address": "25 School St."
     },
     "description": "The Leominster session of the Central Division of the Housing Court serves Ashburnham, Athol, Fitchburg, Gardner, Holden, Hubbardston, Leominster, Lunenberg, Petersham, Phillipston, Princeton, Royalston, Templeton, Westminster, and Winchendon.",
-    "court_code": "H85"
+    "court_code": "H85",
+    "tyler_code": "535",
+    "lower_court_code": "1831"
   },
   {
     "fax": "",
@@ -57,7 +61,9 @@
       "address": "45 Williams St."
     },
     "description": "The Marlborough session of the Central Division of the Housing Court serves Ashland, Berlin, Bolton, Framingham, Harvard, Holliston, Hopkinton, Hudson, Marlborough, Natick, Northborough, Sherborn, Southborough, Sudbury, Wayland, and Westborough. ",
-    "court_code": "H85"
+    "court_code": "H85",
+    "tyler_code": "535",
+    "lower_court_code": "1831"
   },
   {
     "fax": "",
@@ -77,7 +83,9 @@
       "address": "225 Main St."
     },
     "description": "The Worcester session of the Central Division of the Housing Court serves Auburn, Barre, Bellingham, Blackstone, Boylston, Brookfield, Clinton, Douglas, East Brookfield, Grafton, Hardwick, Hopedale, Lancaster, Leicester, Mendon, Milford, Millbury, Millville, New Braintree, Northbridge, North Brookfield, Oakham, Oxford, Paxton, Rutland, Shrewsbury, Spencer, Sterling, Sutton, Upton, Uxbridge, Warren, West Boylston, and Worcester.",
-    "court_code": "H85"
+    "court_code": "H85",
+    "tyler_code": "535",
+    "lower_court_code": "1831"
   },
   {
     "fax": "",
@@ -98,7 +106,8 @@
     },
     "description": "The Eastern Division of the Housing Court serves Boston, Brookline and Newton.",
     "court_code": "H84",
-    "tyler_id": "537"
+    "tyler_code": "537",
+    "lower_court_code": "1827"
   },
   {
     "fax": "(508) 894-4168",
@@ -119,7 +128,8 @@
       "unit": "Suite 160"
     },
     "description": "The Metro South Housing Court - Brockton Session serves Abington, Avon, Bellingham, Braintree, Bridgewater, Brockton, Canton, Cohasset, Dedham, Dover, East Bridgewater, Eastham, Foxborough, Franklin, Holbrook, Medfield, Medway, Millis, Milton, Needham, Norfolk, Norwood, Plainville, Quincy, Randolph, Sharon, Stoughton, Walpole, Wellesley, West Bridgewater, Westwood, Weymouth, Whitman, and Wrentham.",
-    "court_code": "H82"
+    "court_code": "H82",
+    "tyler_code": "1550"
   },
   {
     "fax": "(508) 894-4166",
@@ -139,7 +149,8 @@
       "address": "35 Shawmut Road"
     },
     "description": "This court serves all cities and towns in Norfolk County. The Housing Court is on the second floor of the building. The Canton Session is only available on Fridays. Filings cannot be accepted in Canton at any other time. Please do not file paperwork with the Register's Office. ",
-    "court_code": "H82"
+    "court_code": "H82",
+    "tyler_code": "1550"
   },
   {
     "fax": "",
@@ -160,7 +171,8 @@
       "unit": "2nd Floor"
     },
     "description": "The Lawrence Session of the Northeast Housing Court serves Amesbury, Andover, Boxford, Georgetown, Groveland, Haverhill, Lawrence, Merrimac, Methuen, Newbury, Newburyport, North Andover, Rowley, Salisbury, and West Newbury.  ",
-    "court_code": "H77"
+    "court_code": "H77",
+    "tyler_code": "516"
   },
   {
     "fax": "",
@@ -180,7 +192,8 @@
       "address": "360 Gorham St."
     },
     "description": "The Lowell session of the Northeast Housing Court serves Acton, Ashby, Ayer, Billerica, Boxborough, Carlisle, Chelmsford, Devens, Dracut, Dunstable, Groton, Littleton, Lowell, Maynard, Pepperell, Shirley, Stow, Tewksbury, Townsend, Tyngsborough, and Westford.",
-    "court_code": "H77"
+    "court_code": "H77",
+    "tyler_code": "516"
   },
   {
     "fax": "",
@@ -200,7 +213,9 @@
       "address": "56 Federal"
     },
     "description": "The Lynn session of the Northeast Housing Court is located in Salem and serves Lynn, Nahant, and Saugus.",
-    "court_code": "H77"
+    "court_code": "H77",
+    "tyler_code": "516",
+    "lower_court_code": "1828"
   },
   {
     "fax": "",
@@ -220,7 +235,9 @@
       "address": "56 Federal"
     },
     "description": "The Salem session of the Northeast Housing Court serves Beverly, Danvers, Essex, Gloucester, Hamilton, Ipswich, Lynnfield, Manchester-by-The-Sea, Marblehead, Middleton, Peabody, Rockport, Salem, Swampscott, Topsfield, and Wenham.",
-    "court_code": "H77"
+    "court_code": "H77",
+    "tyler_code": "516",
+    "lower_court_code": "1828"
   },
   {
     "fax": "",
@@ -241,7 +258,9 @@
       "unit": "Courtroom 540 5th Floor"
     },
     "description": "The Woburn session of the Northeast Housing Court serves Bedford, Burlington, Concord, Everett,Lexington, Lincoln, Malden, Melrose, North Reading, Reading, Stoneham, Wakefield, Waltham, Watertown, Weston, Wilmington, Winchester, and Woburn.",
-    "court_code": "H77"
+    "court_code": "H77",
+    "tyler_code": "516",
+    "lower_court_code": "1828"
   },
   {
     "fax": "(508) 672-9621",
@@ -261,7 +280,9 @@
       "address": "289 Rock St."
     },
     "description": "The Fall River Session of the Southeast Housing Court serves Freetown, Westport, Fall River, Somerset and Swansea.",
-    "court_code": "H83"
+    "court_code": "H83",
+    "tyler_code": "555:FR",
+    "lower_court_code": "1829"
   },
   {
     "fax": "(508) 994-7538",
@@ -281,7 +302,9 @@
       "address": "139 Hathaway Road"
     },
     "description": "The New Bedford Session of the Southeast Housing Court serves Acushnet, Dartmouth, Fairhaven, Freetown, New Bedford and Westport.",
-    "court_code": "H83"
+    "court_code": "H83",
+    "tyler_code": "555:NB",
+    "lower_court_code": "1829"
   },
   {
     "fax": "(508) 747-2017",
@@ -301,7 +324,9 @@
       "address": "52 Obery St."
     },
     "description": "The Plymouth session of the Southeast Housing Court serves Accord, Aquinnah, Assinippi, Barnstable, Bourne, Brewster, Carver, Chatham, Chilmark, Dennis, Duxbury, Edgartown, Falmouth, Halifax, Hanover, Hanson, Harwich, Hingham, Hull, Humarock, Kingston, Lakeville, Marion, Marshfield, Mashpee, Mattapoisett, Middleborough, Nantucket, Norwell, Oak Bluffs, Pembroke, Plymouth, Plympton, Provincetown, Rochester, Rockland, Sandwich, Scituate, and Wareham.",
-    "court_code": "H83"
+    "court_code": "H83",
+    "tyler_code": "555:PL",
+    "lower_court_code": "1829"
   },
   {
     "fax": "(508) 977-0485",
@@ -321,7 +346,9 @@
       "address": "40 Broadway"
     },
     "description": "The Taunton Session of the Southeast Housing Court serves Attleboro, Berkley, Dighton, Easton, Mansfield, North Attleborough, Norton, Raynham, Rehoboth, Seekonk and Taunton.",
-    "court_code": "H83"
+    "court_code": "H83",
+    "tyler_code": "555:TA",
+    "lower_court_code": "1829"
   },
   {
     "fax": "(413) 732-4607",
@@ -341,7 +368,9 @@
       "address": "43 Hope St."
     },
     "description": "The Western Housing Court in Greenfield serves Ashfield, Bernardston, Buckland, Charlemont, Colrain, Conway, Deerfield, Erving, Gill, Greenfield, Hawley, Heath, Leverett, Leyden, Monroe, Montague, New Salem, Northfield, Orange, Rowe, Shelburne, Shutesbury, Sunderland, Warwick, Wendell and Whately.",
-    "court_code": "H79"
+    "court_code": "H79",
+    "tyler_code": "527",
+    "lower_court_code": "1830"
   },
   {
     "fax": "(413) 732-4607 ",
@@ -361,7 +390,9 @@
       "address": "116 Russell St."
     },
     "description": "The Hadley session of the Western Housing Court serves Amherst, Belchertown, Chesterfield, Cummington, Easthampton, Goshen, Granby, Hadley, Hatfield, Huntington, Middlefield, Northampton, Pelham, Plainfield, South Hadley, Southampton, Ware, Westhampton, Williamsburg and Worthington.",
-    "court_code": "H79"
+    "court_code": "H79",
+    "tyler_code": "527",
+    "lower_court_code": "1830"
   },
   {
     "fax": "(413) 732-4607 ",
@@ -382,7 +413,9 @@
       "unit": "Room 2"
     },
     "description": "The Pittsfield session of the Western Housing Court serves cities and towns in Berkshire County on Wednesday mornings.",
-    "court_code": "H79"
+    "court_code": "H79",
+    "tyler_code": "527",
+    "lower_court_code": "1830"
   },
   {
     "fax": "(413) 732-4607",
@@ -402,11 +435,14 @@
       "address": "37 Elm Street, P.O. Box 559"
     },
     "description": "The Western Housing Court in Springfield serves Agawam, Blandford, Brimfield, Chester, Chicopee, East Longmeadow, Granville, Hampden, Holland, Holyoke, Longmeadow, Ludlow, Monson, Montgomery, Palmer, Russell, Southwick, Springfield, Tolland, Wales, West Springfield, Westfield and Wilbraham.",
-    "court_code": "H79"
+    "court_code": "H79",
+    "tyler_code": "527",
+    "lower_court_code": "1830"
   },
   {
     "fax": "",
     "court_code": "H84",
+    "tyler_code": "537",
     "name": "Eastern Housing Court - Middlesex Session",
     "phone": "(781) 306-2715",
     "has_po_box": false,
@@ -422,11 +458,13 @@
       "county": "Middlesex County",
       "orig_address": "4040 Mystic Valley Parkway, Medford, MA 02155"
     },
-    "description": "The Middlesex Session of the Eastern Housing Court serves Arlington, Belmont, and Cambridge, Medford and Somerville"
+    "description": "The Middlesex Session of the Eastern Housing Court serves Arlington, Belmont, and Cambridge, Medford and Somerville",
+    "lower_court_code": "1827"
   },
   {
     "fax": "(508)362-0290",
     "court_code": "H83",
+    "tyler_code": "1556",
     "name": "Southeast Housing Court - Barnstable session",
     "phone": "(508)375-6967",
     "has_po_box": true,
@@ -442,11 +480,13 @@
       "state": "MA",
       "address": "3195 Main Street"
     },
-    "description": "The Barnstable session of the Southeast Housing court is located in Barnstable, MA and serves Barnstable, Nantucket, and Dukes counties."
+    "description": "The Barnstable session of the Southeast Housing court is located in Barnstable, MA and serves Barnstable, Nantucket, and Dukes counties.",
+    "lower_court_code": "1829"
   },
   {
     "fax": "",
     "court_code": "H84",
+    "tyler_code": "537",
     "name": "Eastern Housing Court - Chelsea Session",
     "phone": "(617)788-8485",
     "has_po_box": false,
@@ -462,6 +502,7 @@
       "state": "MA",
       "address": "120 Broadway, Chelsea, MA 02150"
     },
-    "description": "The Chelsea session of Eastern Housing Court is located in Chelsea District Court and serves Chelsea, Revere, Winthrop and East Boston."
+    "description": "The Chelsea session of Eastern Housing Court is located in Chelsea District Court and serves Chelsea, Revere, Winthrop and East Boston.",
+    "lower_court_code": "1827"
   }
 ]

--- a/docassemble/MACourts/data/sources/housing_courts.json
+++ b/docassemble/MACourts/data/sources/housing_courts.json
@@ -19,7 +19,7 @@
     "description": "The Dudley session of the Central Division of the Housing Court serves Charlton, Dudley, Oxford, Southbridge, Sturbridge, and Webster",
     "court_code": "H85",
     "tyler_code": "535",
-    "lower_court_code": "1831"
+    "tyler_lower_court_code": "1831"
   },
   {
     "fax": "",
@@ -41,7 +41,7 @@
     "description": "The Leominster session of the Central Division of the Housing Court serves Ashburnham, Athol, Fitchburg, Gardner, Holden, Hubbardston, Leominster, Lunenberg, Petersham, Phillipston, Princeton, Royalston, Templeton, Westminster, and Winchendon.",
     "court_code": "H85",
     "tyler_code": "535",
-    "lower_court_code": "1831"
+    "tyler_lower_court_code": "1831"
   },
   {
     "fax": "",
@@ -63,7 +63,7 @@
     "description": "The Marlborough session of the Central Division of the Housing Court serves Ashland, Berlin, Bolton, Framingham, Harvard, Holliston, Hopkinton, Hudson, Marlborough, Natick, Northborough, Sherborn, Southborough, Sudbury, Wayland, and Westborough. ",
     "court_code": "H85",
     "tyler_code": "535",
-    "lower_court_code": "1831"
+    "tyler_lower_court_code": "1831"
   },
   {
     "fax": "",
@@ -85,7 +85,7 @@
     "description": "The Worcester session of the Central Division of the Housing Court serves Auburn, Barre, Bellingham, Blackstone, Boylston, Brookfield, Clinton, Douglas, East Brookfield, Grafton, Hardwick, Hopedale, Lancaster, Leicester, Mendon, Milford, Millbury, Millville, New Braintree, Northbridge, North Brookfield, Oakham, Oxford, Paxton, Rutland, Shrewsbury, Spencer, Sterling, Sutton, Upton, Uxbridge, Warren, West Boylston, and Worcester.",
     "court_code": "H85",
     "tyler_code": "535",
-    "lower_court_code": "1831"
+    "tyler_lower_court_code": "1831"
   },
   {
     "fax": "",
@@ -107,7 +107,7 @@
     "description": "The Eastern Division of the Housing Court serves Boston, Brookline and Newton.",
     "court_code": "H84",
     "tyler_code": "537",
-    "lower_court_code": "1827"
+    "tyler_lower_court_code": "1827"
   },
   {
     "fax": "(508) 894-4168",
@@ -173,7 +173,7 @@
     "description": "The Lawrence Session of the Northeast Housing Court serves Amesbury, Andover, Boxford, Georgetown, Groveland, Haverhill, Lawrence, Merrimac, Methuen, Newbury, Newburyport, North Andover, Rowley, Salisbury, and West Newbury.  ",
     "court_code": "H77",
     "tyler_code": "516",
-    "lower_court_code": "1828"
+    "tyler_lower_court_code": "1828"
   },
   {
     "fax": "",
@@ -195,7 +195,7 @@
     "description": "The Lowell session of the Northeast Housing Court serves Acton, Ashby, Ayer, Billerica, Boxborough, Carlisle, Chelmsford, Devens, Dracut, Dunstable, Groton, Littleton, Lowell, Maynard, Pepperell, Shirley, Stow, Tewksbury, Townsend, Tyngsborough, and Westford.",
     "court_code": "H77",
     "tyler_code": "516",
-    "lower_court_code": "1828"
+    "tyler_lower_court_code": "1828"
   },
   {
     "fax": "",
@@ -217,7 +217,7 @@
     "description": "The Lynn session of the Northeast Housing Court is located in Salem and serves Lynn, Nahant, and Saugus.",
     "court_code": "H77",
     "tyler_code": "516",
-    "lower_court_code": "1828"
+    "tyler_lower_court_code": "1828"
   },
   {
     "fax": "",
@@ -239,7 +239,7 @@
     "description": "The Salem session of the Northeast Housing Court serves Beverly, Danvers, Essex, Gloucester, Hamilton, Ipswich, Lynnfield, Manchester-by-The-Sea, Marblehead, Middleton, Peabody, Rockport, Salem, Swampscott, Topsfield, and Wenham.",
     "court_code": "H77",
     "tyler_code": "516",
-    "lower_court_code": "1828"
+    "tyler_lower_court_code": "1828"
   },
   {
     "fax": "",
@@ -262,7 +262,7 @@
     "description": "The Woburn session of the Northeast Housing Court serves Bedford, Burlington, Concord, Everett,Lexington, Lincoln, Malden, Melrose, North Reading, Reading, Stoneham, Wakefield, Waltham, Watertown, Weston, Wilmington, Winchester, and Woburn.",
     "court_code": "H77",
     "tyler_code": "516",
-    "lower_court_code": "1828"
+    "tyler_lower_court_code": "1828"
   },
   {
     "fax": "(508) 672-9621",
@@ -284,7 +284,7 @@
     "description": "The Fall River Session of the Southeast Housing Court serves Freetown, Westport, Fall River, Somerset and Swansea.",
     "court_code": "H83",
     "tyler_code": "555:FR",
-    "lower_court_code": "1829"
+    "tyler_lower_court_code": "1829"
   },
   {
     "fax": "(508) 994-7538",
@@ -306,7 +306,7 @@
     "description": "The New Bedford Session of the Southeast Housing Court serves Acushnet, Dartmouth, Fairhaven, Freetown, New Bedford and Westport.",
     "court_code": "H83",
     "tyler_code": "555:NB",
-    "lower_court_code": "1829"
+    "tyler_lower_court_code": "1829"
   },
   {
     "fax": "(508) 747-2017",
@@ -328,7 +328,7 @@
     "description": "The Plymouth session of the Southeast Housing Court serves Accord, Aquinnah, Assinippi, Barnstable, Bourne, Brewster, Carver, Chatham, Chilmark, Dennis, Duxbury, Edgartown, Falmouth, Halifax, Hanover, Hanson, Harwich, Hingham, Hull, Humarock, Kingston, Lakeville, Marion, Marshfield, Mashpee, Mattapoisett, Middleborough, Nantucket, Norwell, Oak Bluffs, Pembroke, Plymouth, Plympton, Provincetown, Rochester, Rockland, Sandwich, Scituate, and Wareham.",
     "court_code": "H83",
     "tyler_code": "555:PL",
-    "lower_court_code": "1829"
+    "tyler_lower_court_code": "1829"
   },
   {
     "fax": "(508) 977-0485",
@@ -350,7 +350,7 @@
     "description": "The Taunton Session of the Southeast Housing Court serves Attleboro, Berkley, Dighton, Easton, Mansfield, North Attleborough, Norton, Raynham, Rehoboth, Seekonk and Taunton.",
     "court_code": "H83",
     "tyler_code": "555:TA",
-    "lower_court_code": "1829"
+    "tyler_lower_court_code": "1829"
   },
   {
     "fax": "(413) 732-4607",
@@ -372,7 +372,7 @@
     "description": "The Western Housing Court in Greenfield serves Ashfield, Bernardston, Buckland, Charlemont, Colrain, Conway, Deerfield, Erving, Gill, Greenfield, Hawley, Heath, Leverett, Leyden, Monroe, Montague, New Salem, Northfield, Orange, Rowe, Shelburne, Shutesbury, Sunderland, Warwick, Wendell and Whately.",
     "court_code": "H79",
     "tyler_code": "527",
-    "lower_court_code": "1830"
+    "tyler_lower_court_code": "1830"
   },
   {
     "fax": "(413) 732-4607 ",
@@ -394,7 +394,7 @@
     "description": "The Hadley session of the Western Housing Court serves Amherst, Belchertown, Chesterfield, Cummington, Easthampton, Goshen, Granby, Hadley, Hatfield, Huntington, Middlefield, Northampton, Pelham, Plainfield, South Hadley, Southampton, Ware, Westhampton, Williamsburg and Worthington.",
     "court_code": "H79",
     "tyler_code": "527",
-    "lower_court_code": "1830"
+    "tyler_lower_court_code": "1830"
   },
   {
     "fax": "(413) 732-4607 ",
@@ -417,7 +417,7 @@
     "description": "The Pittsfield session of the Western Housing Court serves cities and towns in Berkshire County on Wednesday mornings.",
     "court_code": "H79",
     "tyler_code": "527",
-    "lower_court_code": "1830"
+    "tyler_lower_court_code": "1830"
   },
   {
     "fax": "(413) 732-4607",
@@ -439,7 +439,7 @@
     "description": "The Western Housing Court in Springfield serves Agawam, Blandford, Brimfield, Chester, Chicopee, East Longmeadow, Granville, Hampden, Holland, Holyoke, Longmeadow, Ludlow, Monson, Montgomery, Palmer, Russell, Southwick, Springfield, Tolland, Wales, West Springfield, Westfield and Wilbraham.",
     "court_code": "H79",
     "tyler_code": "527",
-    "lower_court_code": "1830"
+    "tyler_lower_court_code": "1830"
   },
   {
     "fax": "",
@@ -461,7 +461,7 @@
       "orig_address": "4040 Mystic Valley Parkway, Medford, MA 02155"
     },
     "description": "The Middlesex Session of the Eastern Housing Court serves Arlington, Belmont, and Cambridge, Medford and Somerville",
-    "lower_court_code": "1827"
+    "tyler_lower_court_code": "1827"
   },
   {
     "fax": "(508)362-0290",
@@ -483,7 +483,7 @@
       "address": "3195 Main Street"
     },
     "description": "The Barnstable session of the Southeast Housing court is located in Barnstable, MA and serves Barnstable, Nantucket, and Dukes counties.",
-    "lower_court_code": "1829"
+    "tyler_lower_court_code": "1829"
   },
   {
     "fax": "",
@@ -505,6 +505,6 @@
       "address": "120 Broadway, Chelsea, MA 02150"
     },
     "description": "The Chelsea session of Eastern Housing Court is located in Chelsea District Court and serves Chelsea, Revere, Winthrop and East Boston.",
-    "lower_court_code": "1827"
+    "tyler_lower_court_code": "1827"
   }
 ]

--- a/docassemble/MACourts/data/sources/housing_courts.json
+++ b/docassemble/MACourts/data/sources/housing_courts.json
@@ -172,7 +172,8 @@
     },
     "description": "The Lawrence Session of the Northeast Housing Court serves Amesbury, Andover, Boxford, Georgetown, Groveland, Haverhill, Lawrence, Merrimac, Methuen, Newbury, Newburyport, North Andover, Rowley, Salisbury, and West Newbury.  ",
     "court_code": "H77",
-    "tyler_code": "516"
+    "tyler_code": "516",
+    "lower_court_code": "1828"
   },
   {
     "fax": "",
@@ -193,7 +194,8 @@
     },
     "description": "The Lowell session of the Northeast Housing Court serves Acton, Ashby, Ayer, Billerica, Boxborough, Carlisle, Chelmsford, Devens, Dracut, Dunstable, Groton, Littleton, Lowell, Maynard, Pepperell, Shirley, Stow, Tewksbury, Townsend, Tyngsborough, and Westford.",
     "court_code": "H77",
-    "tyler_code": "516"
+    "tyler_code": "516",
+    "lower_court_code": "1828"
   },
   {
     "fax": "",

--- a/docassemble/MACourts/data/sources/juvenile_courts.json
+++ b/docassemble/MACourts/data/sources/juvenile_courts.json
@@ -2,7 +2,7 @@
   {
     "fax": "",
     "court_code": "J34",
-    "lower_court_code": "1839",
+    "tyler_lower_court_code": "1839",
     "name": "Attleboro Juvenile Court",
     "phone": "(508) 222-5350",
     "has_po_box": false,
@@ -23,7 +23,7 @@
   {
     "fax": "",
     "court_code": "J25",
-    "lower_court_code": "1832",
+    "tyler_lower_court_code": "1832",
     "name": "Barnstable Juvenile Court",
     "phone": "(508) 362-1389",
     "has_po_box": true,
@@ -44,7 +44,7 @@
   {
     "fax": "",
     "court_code": "J46",
-    "lower_court_code": "1845",
+    "tyler_lower_court_code": "1845",
     "name": "Belchertown Juvenile Court",
     "phone": "(413) 323-4056",
     "has_po_box": false,
@@ -65,7 +65,7 @@
   {
     "fax": "(617) 788-8991",
     "court_code": "71",
-    "lower_court_code": "1852",
+    "tyler_lower_court_code": "1852",
     "name": "Boston Juvenile Court",
     "phone": "(617) 788-8525",
     "has_po_box": true,
@@ -86,7 +86,7 @@
   {
     "fax": "",
     "court_code": "J15",
-    "lower_court_code": "1849",
+    "tyler_lower_court_code": "1849",
     "name": "Brockton Juvenile Court",
     "phone": "(508) 897-4900",
     "has_po_box": false,
@@ -107,7 +107,7 @@
   {
     "fax": "",
     "court_code": "J52",
-    "lower_court_code": "1847",
+    "tyler_lower_court_code": "1847",
     "name": "Cambridge Juvenile Court",
     "phone": "(617) 494-4100",
     "has_po_box": false,
@@ -128,7 +128,7 @@
   {
     "fax": "(617) 660-9222",
     "court_code": "J14",
-    "lower_court_code": "1852",
+    "tyler_lower_court_code": "1852",
     "name": "Chelsea Juvenile Court",
     "phone": "(617) 660-9225",
     "has_po_box": false,
@@ -149,7 +149,7 @@
   {
     "fax": "",
     "court_code": "J54",
-    "lower_court_code": "1848",
+    "tyler_lower_court_code": "1848",
     "name": "Dedham Juvenile Court",
     "phone": "(781) 329-1500",
     "has_po_box": false,
@@ -170,7 +170,7 @@
   {
     "fax": "(617) 436-3595",
     "court_code": "J7",
-    "lower_court_code": "1852",
+    "tyler_lower_court_code": "1852",
     "name": "Dorchester Juvenile Court",
     "phone": "(617) 288-9500 x400",
     "has_po_box": false,
@@ -191,7 +191,7 @@
   {
     "fax": "",
     "court_code": "J64",
-    "lower_court_code": "1853",
+    "tyler_lower_court_code": "1853",
     "name": "Dudley Juvenile Court",
     "phone": "(508) 949-3070",
     "has_po_box": false,
@@ -212,7 +212,7 @@
   {
     "fax": "",
     "court_code": "J35",
-    "lower_court_code": "1833",
+    "tyler_lower_court_code": "1833",
     "name": "Edgartown Juvenile Court",
     "phone": "(508) 627-8983",
     "has_po_box": true,
@@ -234,7 +234,7 @@
   {
     "fax": "",
     "court_code": "J32",
-    "lower_court_code": "1840",
+    "tyler_lower_court_code": "1840",
     "name": "Fall River Juvenile Court",
     "phone": "(508) 676-0090",
     "has_po_box": false,
@@ -256,7 +256,7 @@
   {
     "fax": "",
     "court_code": "J89",
-    "lower_court_code": "1834",
+    "tyler_lower_court_code": "1834",
     "name": "Falmouth Juvenile Court",
     "phone": "(508) 495-1696",
     "has_po_box": false,
@@ -277,7 +277,7 @@
   {
     "fax": "",
     "court_code": "J16",
-    "lower_court_code": "1853",
+    "tyler_lower_court_code": "1853",
     "name": "Fitchburg Juvenile Court",
     "phone": "(978) 345-7620",
     "has_po_box": false,
@@ -298,7 +298,7 @@
   {
     "fax": "",
     "court_code": "J49",
-    "lower_court_code": "1847",
+    "tyler_lower_court_code": "1847",
     "name": "Framingham Juvenile Court",
     "phone": "(508) 879-3561",
     "has_po_box": false,
@@ -319,7 +319,7 @@
   {
     "fax": "",
     "court_code": "J29",
-    "lower_court_code": "1838",
+    "tyler_lower_court_code": "1838",
     "name": "Great Barrington Juvenile Court",
     "phone": "(413) 528-3520",
     "has_po_box": false,
@@ -340,7 +340,7 @@
   {
     "fax": "(413) 775-9201",
     "court_code": "J41",
-    "lower_court_code": "1845",
+    "tyler_lower_court_code": "1845",
     "name": "Greenfield Juvenile Court",
     "phone": "(413) 775-0014",
     "has_po_box": false,
@@ -361,7 +361,7 @@
   {
     "fax": "(413) 587-0191",
     "court_code": "J45",
-    "lower_court_code": "1845",
+    "tyler_lower_court_code": "1845",
     "name": "Hadley Juvenile Court",
     "phone": "(413) 584-7686",
     "has_po_box": false,
@@ -383,7 +383,7 @@
   {
     "fax": "",
     "court_code": "J58",
-    "lower_court_code": "1850",
+    "tyler_lower_court_code": "1850",
     "name": "Hingham Juvenile Court",
     "phone": "(781) 741-6007",
     "has_po_box": false,
@@ -404,7 +404,7 @@
   {
     "fax": "",
     "court_code": "J17",
-    "lower_court_code": "1846",
+    "tyler_lower_court_code": "1846",
     "name": "Holyoke Juvenile Court",
     "phone": "(413) 322-6700",
     "has_po_box": false,
@@ -425,7 +425,7 @@
   {
     "fax": "",
     "court_code": "J18",
-    "lower_court_code": "1844",
+    "tyler_lower_court_code": "1844",
     "name": "Lawrence Juvenile Court",
     "phone": "(978) 725-4900 x2",
     "has_po_box": false,
@@ -447,7 +447,7 @@
   {
     "fax": "",
     "court_code": "J11",
-    "lower_court_code": "1847",
+    "tyler_lower_court_code": "1847",
     "name": "Lowell Juvenile Court",
     "phone": "(978) 441-2630",
     "has_po_box": false,
@@ -468,7 +468,7 @@
   {
     "fax": "",
     "court_code": "J13",
-    "lower_court_code": "1844",
+    "tyler_lower_court_code": "1844",
     "name": "Lynn Juvenile Court",
     "phone": " (781) 586-0415 x4",
     "has_po_box": false,
@@ -489,7 +489,7 @@
   {
     "fax": "",
     "court_code": "J66",
-    "lower_court_code": "1853",
+    "tyler_lower_court_code": "1853",
     "name": "Milford Juvenile Court",
     "phone": "(508) 478-8638",
     "has_po_box": false,
@@ -510,7 +510,7 @@
   {
     "fax": "",
     "court_code": "J88",
-    "lower_court_code": "1835",
+    "tyler_lower_court_code": "1835",
     "name": "Nantucket Juvenile Court",
     "phone": "",
     "has_po_box": false,
@@ -531,7 +531,7 @@
   {
     "fax": "",
     "court_code": "J33",
-    "lower_court_code": "1841",
+    "tyler_lower_court_code": "1841",
     "name": "New Bedford Juvenile Court",
     "phone": "(508) 999-9700",
     "has_po_box": false,
@@ -552,7 +552,7 @@
   {
     "fax": "",
     "court_code": "J22",
-    "lower_court_code": "1844", 
+    "tyler_lower_court_code": "1844", 
     "name": "Newburyport Juvenile Court",
     "phone": "(978) 462-0617 x5",
     "has_po_box": false,
@@ -573,7 +573,7 @@
   {
     "fax": "413-664-7788",
     "court_code": "J28",
-    "lower_court_code": "1838",
+    "tyler_lower_court_code": "1838",
     "name": "North Adams Juvenile Court",
     "phone": "(413) 664-8700",
     "has_po_box": false,
@@ -594,7 +594,7 @@
   {
     "fax": "",
     "court_code": "J42",
-    "lower_court_code": "1845",
+    "tyler_lower_court_code": "1845",
     "name": "Orange Juvenile Court",
     "phone": "(978) 544-5125",
     "has_po_box": false,
@@ -615,7 +615,7 @@
   {
     "fax": "",
     "court_code": "J26",
-    "lower_court_code": "1836",
+    "tyler_lower_court_code": "1836",
     "name": "Orleans Juvenile Court",
     "phone": "(508) 240-5044",
     "has_po_box": false,
@@ -636,7 +636,7 @@
   {
     "fax": "",
     "court_code": "J43",
-    "lower_court_code": "1846",
+    "tyler_lower_court_code": "1846",
     "name": "Palmer Juvenile Court",
     "phone": "(413) 283-1057",
     "has_po_box": false,
@@ -658,7 +658,7 @@
   {
     "fax": "413-443-8672",
     "court_code": "J27",
-    "lower_court_code": "1838",
+    "tyler_lower_court_code": "1838",
     "name": "Pittsfield Juvenile Court",
     "phone": "(413) 443-8533",
     "has_po_box": false,
@@ -679,7 +679,7 @@
   {
     "fax": "",
     "court_code": "J59",
-    "lower_court_code": "1837",
+    "tyler_lower_court_code": "1837",
     "name": "Plymouth Juvenile Court",
     "phone": "(508) 747-0858",
     "has_po_box": false,
@@ -701,7 +701,7 @@
   {
     "fax": "",
     "court_code": "J56",
-    "lower_court_code": "1848",
+    "tyler_lower_court_code": "1848",
     "name": "Quincy Juvenile Court",
     "phone": "(617) 376-7505",
     "has_po_box": false,
@@ -722,7 +722,7 @@
   {
     "fax": "",
     "court_code": "J36",
-    "lower_court_code": "1844",
+    "tyler_lower_court_code": "1844",
     "name": "Salem Juvenile Court",
     "phone": "(978) 745-9660 x1",
     "has_po_box": false,
@@ -743,7 +743,7 @@
   {
     "fax": "",
     "court_code": "J23",
-    "lower_court_code": "1846",
+    "tyler_lower_court_code": "1846",
     "name": "Springfield Juvenile Court",
     "phone": "(413) 748-7860",
     "has_po_box": false,
@@ -764,7 +764,7 @@
   {
     "fax": "",
     "court_code": "J69",
-    "lower_court_code": "1846",
+    "tyler_lower_court_code": "1846",
     "name": "Springfield Juvenile Court",
     "phone": "(413) 748-7860",
     "has_po_box": false,
@@ -785,7 +785,7 @@
   {
     "fax": "",
     "court_code": "J55",
-    "lower_court_code": "1848",
+    "tyler_lower_court_code": "1848",
     "name": "Stoughton Juvenile Court",
     "phone": "",
     "has_po_box": false,
@@ -806,7 +806,7 @@
   {
     "fax": "",
     "court_code": "J31",
-    "lower_court_code": "1842",
+    "tyler_lower_court_code": "1842",
     "name": "Taunton Juvenile Court",
     "phone": "(508) 977-4910",
     "has_po_box": false,
@@ -828,7 +828,7 @@
   {
     "fax": "",
     "court_code": "J51",
-    "lower_court_code": "1847",
+    "tyler_lower_court_code": "1847",
     "name": "Waltham Juvenile Court",
     "phone": "(781) 899-7672",
     "has_po_box": false,
@@ -849,7 +849,7 @@
   {
     "fax": "",
     "court_code": "J60",
-    "lower_court_code": "1851",
+    "tyler_lower_court_code": "1851",
     "name": "Wareham Juvenile Court",
     "phone": "(508) 291-8407",
     "has_po_box": false,
@@ -870,7 +870,7 @@
   {
     "fax": "(617) 524-7335",
     "court_code": "J6",
-    "lower_court_code": "1852",
+    "tyler_lower_court_code": "1852",
     "name": "West Roxbury Juvenile Court",
     "phone": "(617) 971-1154",
     "has_po_box": false,
@@ -891,7 +891,7 @@
   {
     "fax": "",
     "court_code": "J62",
-    "lower_court_code": "1853",
+    "tyler_lower_court_code": "1853",
     "name": "Worcester Juvenile Court",
     "phone": "(508) 831-2000",
     "has_po_box": false,

--- a/docassemble/MACourts/data/sources/juvenile_courts.json
+++ b/docassemble/MACourts/data/sources/juvenile_courts.json
@@ -2,6 +2,7 @@
   {
     "fax": "",
     "court_code": "J34",
+    "lower_court_code": "1839",
     "name": "Attleboro Juvenile Court",
     "phone": "(508) 222-5350",
     "has_po_box": false,
@@ -22,6 +23,7 @@
   {
     "fax": "",
     "court_code": "J25",
+    "lower_court_code": "1832",
     "name": "Barnstable Juvenile Court",
     "phone": "(508) 362-1389",
     "has_po_box": true,
@@ -42,6 +44,7 @@
   {
     "fax": "",
     "court_code": "J46",
+    "lower_court_code": "1845",
     "name": "Belchertown Juvenile Court",
     "phone": "(413) 323-4056",
     "has_po_box": false,
@@ -62,6 +65,7 @@
   {
     "fax": "(617) 788-8991",
     "court_code": "71",
+    "lower_court_code": "1852",
     "name": "Boston Juvenile Court",
     "phone": "(617) 788-8525",
     "has_po_box": true,
@@ -82,6 +86,7 @@
   {
     "fax": "",
     "court_code": "J15",
+    "lower_court_code": "1849",
     "name": "Brockton Juvenile Court",
     "phone": "(508) 897-4900",
     "has_po_box": false,
@@ -102,6 +107,7 @@
   {
     "fax": "",
     "court_code": "J52",
+    "lower_court_code": "1847",
     "name": "Cambridge Juvenile Court",
     "phone": "(617) 494-4100",
     "has_po_box": false,
@@ -122,6 +128,7 @@
   {
     "fax": "(617) 660-9222",
     "court_code": "J14",
+    "lower_court_code": "1852",
     "name": "Chelsea Juvenile Court",
     "phone": "(617) 660-9225",
     "has_po_box": false,
@@ -142,6 +149,7 @@
   {
     "fax": "",
     "court_code": "J54",
+    "lower_court_code": "1848",
     "name": "Dedham Juvenile Court",
     "phone": "(781) 329-1500",
     "has_po_box": false,
@@ -162,6 +170,7 @@
   {
     "fax": "(617) 436-3595",
     "court_code": "J7",
+    "lower_court_code": "1852",
     "name": "Dorchester Juvenile Court",
     "phone": "(617) 288-9500 x400",
     "has_po_box": false,
@@ -182,6 +191,7 @@
   {
     "fax": "",
     "court_code": "J64",
+    "lower_court_code": "1853",
     "name": "Dudley Juvenile Court",
     "phone": "(508) 949-3070",
     "has_po_box": false,
@@ -202,6 +212,7 @@
   {
     "fax": "",
     "court_code": "J35",
+    "lower_court_code": "1833",
     "name": "Edgartown Juvenile Court",
     "phone": "(508) 627-8983",
     "has_po_box": true,
@@ -223,6 +234,7 @@
   {
     "fax": "",
     "court_code": "J32",
+    "lower_court_code": "1840",
     "name": "Fall River Juvenile Court",
     "phone": "(508) 676-0090",
     "has_po_box": false,
@@ -244,6 +256,7 @@
   {
     "fax": "",
     "court_code": "J89",
+    "lower_court_code": "1834",
     "name": "Falmouth Juvenile Court",
     "phone": "(508) 495-1696",
     "has_po_box": false,
@@ -264,6 +277,7 @@
   {
     "fax": "",
     "court_code": "J16",
+    "lower_court_code": "1853",
     "name": "Fitchburg Juvenile Court",
     "phone": "(978) 345-7620",
     "has_po_box": false,
@@ -284,6 +298,7 @@
   {
     "fax": "",
     "court_code": "J49",
+    "lower_court_code": "1847",
     "name": "Framingham Juvenile Court",
     "phone": "(508) 879-3561",
     "has_po_box": false,
@@ -304,6 +319,7 @@
   {
     "fax": "",
     "court_code": "J29",
+    "lower_court_code": "1838",
     "name": "Great Barrington Juvenile Court",
     "phone": "(413) 528-3520",
     "has_po_box": false,
@@ -324,6 +340,7 @@
   {
     "fax": "(413) 775-9201",
     "court_code": "J41",
+    "lower_court_code": "1845",
     "name": "Greenfield Juvenile Court",
     "phone": "(413) 775-0014",
     "has_po_box": false,
@@ -344,6 +361,7 @@
   {
     "fax": "(413) 587-0191",
     "court_code": "J45",
+    "lower_court_code": "1845",
     "name": "Hadley Juvenile Court",
     "phone": "(413) 584-7686",
     "has_po_box": false,
@@ -365,6 +383,7 @@
   {
     "fax": "",
     "court_code": "J58",
+    "lower_court_code": "1850",
     "name": "Hingham Juvenile Court",
     "phone": "(781) 741-6007",
     "has_po_box": false,
@@ -385,6 +404,7 @@
   {
     "fax": "",
     "court_code": "J17",
+    "lower_court_code": "1846",
     "name": "Holyoke Juvenile Court",
     "phone": "(413) 322-6700",
     "has_po_box": false,
@@ -405,6 +425,7 @@
   {
     "fax": "",
     "court_code": "J18",
+    "lower_court_code": "1844",
     "name": "Lawrence Juvenile Court",
     "phone": "(978) 725-4900 x2",
     "has_po_box": false,
@@ -426,6 +447,7 @@
   {
     "fax": "",
     "court_code": "J11",
+    "lower_court_code": "1847",
     "name": "Lowell Juvenile Court",
     "phone": "(978) 441-2630",
     "has_po_box": false,
@@ -446,6 +468,7 @@
   {
     "fax": "",
     "court_code": "J13",
+    "lower_court_code": "1844",
     "name": "Lynn Juvenile Court",
     "phone": " (781) 586-0415 x4",
     "has_po_box": false,
@@ -466,6 +489,7 @@
   {
     "fax": "",
     "court_code": "J66",
+    "lower_court_code": "1853",
     "name": "Milford Juvenile Court",
     "phone": "(508) 478-8638",
     "has_po_box": false,
@@ -486,6 +510,7 @@
   {
     "fax": "",
     "court_code": "J88",
+    "lower_court_code": "1835",
     "name": "Nantucket Juvenile Court",
     "phone": "",
     "has_po_box": false,
@@ -506,6 +531,7 @@
   {
     "fax": "",
     "court_code": "J33",
+    "lower_court_code": "1841",
     "name": "New Bedford Juvenile Court",
     "phone": "(508) 999-9700",
     "has_po_box": false,
@@ -526,6 +552,7 @@
   {
     "fax": "",
     "court_code": "J22",
+    "lower_court_code": "1844", 
     "name": "Newburyport Juvenile Court",
     "phone": "(978) 462-0617 x5",
     "has_po_box": false,
@@ -546,6 +573,7 @@
   {
     "fax": "413-664-7788",
     "court_code": "J28",
+    "lower_court_code": "1838",
     "name": "North Adams Juvenile Court",
     "phone": "(413) 664-8700",
     "has_po_box": false,
@@ -566,6 +594,7 @@
   {
     "fax": "",
     "court_code": "J42",
+    "lower_court_code": "1845",
     "name": "Orange Juvenile Court",
     "phone": "(978) 544-5125",
     "has_po_box": false,
@@ -586,6 +615,7 @@
   {
     "fax": "",
     "court_code": "J26",
+    "lower_court_code": "1836",
     "name": "Orleans Juvenile Court",
     "phone": "(508) 240-5044",
     "has_po_box": false,
@@ -606,6 +636,7 @@
   {
     "fax": "",
     "court_code": "J43",
+    "lower_court_code": "1846",
     "name": "Palmer Juvenile Court",
     "phone": "(413) 283-1057",
     "has_po_box": false,
@@ -627,6 +658,7 @@
   {
     "fax": "413-443-8672",
     "court_code": "J27",
+    "lower_court_code": "1838",
     "name": "Pittsfield Juvenile Court",
     "phone": "(413) 443-8533",
     "has_po_box": false,
@@ -647,6 +679,7 @@
   {
     "fax": "",
     "court_code": "J59",
+    "lower_court_code": "1837",
     "name": "Plymouth Juvenile Court",
     "phone": "(508) 747-0858",
     "has_po_box": false,
@@ -668,6 +701,7 @@
   {
     "fax": "",
     "court_code": "J56",
+    "lower_court_code": "1848",
     "name": "Quincy Juvenile Court",
     "phone": "(617) 376-7505",
     "has_po_box": false,
@@ -688,6 +722,7 @@
   {
     "fax": "",
     "court_code": "J36",
+    "lower_court_code": "1844",
     "name": "Salem Juvenile Court",
     "phone": "(978) 745-9660 x1",
     "has_po_box": false,
@@ -708,6 +743,7 @@
   {
     "fax": "",
     "court_code": "J23",
+    "lower_court_code": "1846",
     "name": "Springfield Juvenile Court",
     "phone": "(413) 748-7860",
     "has_po_box": false,
@@ -728,6 +764,7 @@
   {
     "fax": "",
     "court_code": "J69",
+    "lower_court_code": "1846",
     "name": "Springfield Juvenile Court",
     "phone": "(413) 748-7860",
     "has_po_box": false,
@@ -748,6 +785,7 @@
   {
     "fax": "",
     "court_code": "J55",
+    "lower_court_code": "1848",
     "name": "Stoughton Juvenile Court",
     "phone": "",
     "has_po_box": false,
@@ -768,6 +806,7 @@
   {
     "fax": "",
     "court_code": "J31",
+    "lower_court_code": "1842",
     "name": "Taunton Juvenile Court",
     "phone": "(508) 977-4910",
     "has_po_box": false,
@@ -789,6 +828,7 @@
   {
     "fax": "",
     "court_code": "J51",
+    "lower_court_code": "1847",
     "name": "Waltham Juvenile Court",
     "phone": "(781) 899-7672",
     "has_po_box": false,
@@ -809,6 +849,7 @@
   {
     "fax": "",
     "court_code": "J60",
+    "lower_court_code": "1851",
     "name": "Wareham Juvenile Court",
     "phone": "(508) 291-8407",
     "has_po_box": false,
@@ -829,6 +870,7 @@
   {
     "fax": "(617) 524-7335",
     "court_code": "J6",
+    "lower_court_code": "1852",
     "name": "West Roxbury Juvenile Court",
     "phone": "(617) 971-1154",
     "has_po_box": false,
@@ -849,6 +891,7 @@
   {
     "fax": "",
     "court_code": "J62",
+    "lower_court_code": "1853",
     "name": "Worcester Juvenile Court",
     "phone": "(508) 831-2000",
     "has_po_box": false,

--- a/docassemble/MACourts/data/sources/land_court.json
+++ b/docassemble/MACourts/data/sources/land_court.json
@@ -2,7 +2,7 @@
   {
     "fax": "",
     "court_code": "unknown",
-    "lower_court_code": "1854",
+    "tyler_lower_court_code": "1854",
     "name": "Land Court",
     "phone": "",
     "has_po_box": false,

--- a/docassemble/MACourts/data/sources/land_court.json
+++ b/docassemble/MACourts/data/sources/land_court.json
@@ -2,6 +2,7 @@
   {
     "fax": "",
     "court_code": "unknown",
+    "lower_court_code": "1854",
     "name": "Land Court",
     "phone": "",
     "has_po_box": false,

--- a/docassemble/MACourts/data/sources/probate_and_family_courts.json
+++ b/docassemble/MACourts/data/sources/probate_and_family_courts.json
@@ -2,7 +2,7 @@
   {
     "fax": "(508) 362-3662",
     "court_code": "P72",
-    "lower_court_code": "1855",
+    "tyler_lower_court_code": "1855",
     "name": "Barnstable Probate and Family Court",
     "phone": "(508) 375-6710",
     "has_po_box": true,
@@ -23,7 +23,7 @@
   {
     "fax": "(413) 443-3430",
     "court_code": "P76",
-    "lower_court_code": "1856",
+    "tyler_lower_court_code": "1856",
     "name": "Berkshire Probate and Family Court",
     "phone": "(413) 442-6941",
     "has_po_box": false,
@@ -44,7 +44,7 @@
   {
     "fax": "",
     "court_code": "P73",
-    "lower_court_code": "1857",
+    "tyler_lower_court_code": "1857",
     "name": "Bristol Probate and Family Court",
     "phone": "(508) 977-6040",
     "has_po_box": false,
@@ -66,7 +66,7 @@
   {
     "fax": "(508) 584-4142",
     "court_code": "P83",
-    "lower_court_code": "1866",
+    "tyler_lower_court_code": "1866",
     "name": "Brockton Probate and Family Court",
     "phone": "(508) 897-5400",
     "has_po_box": false,
@@ -87,7 +87,7 @@
   {
     "fax": "(508) 627-7664",
     "court_code": "P74",
-    "lower_court_code": "1858",
+    "tyler_lower_court_code": "1858",
     "name": "Dukes Probate and Family Court",
     "phone": "(508) 627-4703",
     "has_po_box": true,
@@ -108,7 +108,7 @@
   {
     "fax": "",
     "court_code": "P77",
-    "lower_court_code": "1859",
+    "tyler_lower_court_code": "1859",
     "name": "Essex Probate and Family Court",
     "phone": "(978) 744-1020",
     "has_po_box": false,
@@ -129,7 +129,7 @@
   {
     "fax": "",
     "court_code": "P77",
-    "lower_court_code": "1859",
+    "tyler_lower_court_code": "1859",
     "name": "Lawrence Probate and Family Court",
     "phone": "(978) 686-9692",
     "has_po_box": false,
@@ -151,7 +151,7 @@
   {
     "fax": "(413) 774-3829",
     "court_code": "P78",
-    "lower_court_code": "1860",
+    "tyler_lower_court_code": "1860",
     "name": "Franklin Probate and Family Court",
     "phone": "(413) 774-7011",
     "has_po_box": false,
@@ -172,7 +172,7 @@
   {
     "fax": "(413) 781-5605",
     "court_code": "P79",
-    "lower_court_code": "1861",
+    "tyler_lower_court_code": "1861",
     "name": "Hampden Probate and Family Court",
     "phone": "(413) 748-7760",
     "has_po_box": true,
@@ -193,7 +193,7 @@
   {
     "fax": "(413) 584-1132",
     "court_code": "P80",
-    "lower_court_code": "1862",
+    "tyler_lower_court_code": "1862",
     "name": "Hampshire Probate and Family Court",
     "phone": "(413) 586-8500",
     "has_po_box": false,
@@ -215,7 +215,7 @@
   {
     "fax": "(781) 528-2318",
     "court_code": "P81",
-    "lower_court_code": "1863",
+    "tyler_lower_court_code": "1863",
     "name": "Middlesex Probate and Family Court - South",
     "phone": "(781) 865-4000",
     "has_po_box": false,
@@ -236,7 +236,7 @@
     {
     "fax": "(978) 619-1014",
     "court_code": "P81",
-    "lower_court_code": "1863",
+    "tyler_lower_court_code": "1863",
     "name": "Middlesex Probate and Family Court - North",
     "phone": "(978) 656-7700",
     "has_po_box": false,
@@ -257,7 +257,7 @@
   {
     "fax": "(508) 228-3662",
     "court_code": "P75",
-    "lower_court_code": "1864",
+    "tyler_lower_court_code": "1864",
     "name": "Nantucket Probate and Family Court",
     "phone": "(508) 228-2669",
     "has_po_box": false,
@@ -278,7 +278,7 @@
   {
     "fax": "(781) 830-4310",
     "court_code": "P82",
-    "lower_court_code": "1865",
+    "tyler_lower_court_code": "1865",
     "name": "Norfolk Probate and Family Court",
     "phone": "(781) 830-1200",
     "has_po_box": false,
@@ -299,7 +299,7 @@
   {
     "fax": "(508) 746-6846",
     "court_code": "P83",
-    "lower_court_code": "1866",
+    "tyler_lower_court_code": "1866",
     "name": "Plymouth Probate and Family Court",
     "phone": "(508) 747-6204",
     "has_po_box": false,
@@ -320,7 +320,7 @@
   {
     "fax": "(617) 788-8962",
     "court_code": "P84",
-    "lower_court_code": "1867",
+    "tyler_lower_court_code": "1867",
     "name": "Suffolk Probate and Family Court",
     "phone": "(617) 788-8301",
     "has_po_box": false,
@@ -341,7 +341,7 @@
   {
     "fax": "(508) 752-6138",
     "court_code": "P85",
-    "lower_court_code": "1868",
+    "tyler_lower_court_code": "1868",
     "name": "Worcester Probate and Family Court",
     "phone": "(508) 831-2200",
     "has_po_box": false,

--- a/docassemble/MACourts/data/sources/probate_and_family_courts.json
+++ b/docassemble/MACourts/data/sources/probate_and_family_courts.json
@@ -2,6 +2,7 @@
   {
     "fax": "(508) 362-3662",
     "court_code": "P72",
+    "lower_court_code": "1855",
     "name": "Barnstable Probate and Family Court",
     "phone": "(508) 375-6710",
     "has_po_box": true,
@@ -22,6 +23,7 @@
   {
     "fax": "(413) 443-3430",
     "court_code": "P76",
+    "lower_court_code": "1856",
     "name": "Berkshire Probate and Family Court",
     "phone": "(413) 442-6941",
     "has_po_box": false,
@@ -42,6 +44,7 @@
   {
     "fax": "",
     "court_code": "P73",
+    "lower_court_code": "1857",
     "name": "Bristol Probate and Family Court",
     "phone": "(508) 977-6040",
     "has_po_box": false,
@@ -63,6 +66,7 @@
   {
     "fax": "(508) 584-4142",
     "court_code": "P83",
+    "lower_court_code": "1866",
     "name": "Brockton Probate and Family Court",
     "phone": "(508) 897-5400",
     "has_po_box": false,
@@ -83,6 +87,7 @@
   {
     "fax": "(508) 627-7664",
     "court_code": "P74",
+    "lower_court_code": "1858",
     "name": "Dukes Probate and Family Court",
     "phone": "(508) 627-4703",
     "has_po_box": true,
@@ -103,6 +108,7 @@
   {
     "fax": "",
     "court_code": "P77",
+    "lower_court_code": "1859",
     "name": "Essex Probate and Family Court",
     "phone": "(978) 744-1020",
     "has_po_box": false,
@@ -123,6 +129,7 @@
   {
     "fax": "",
     "court_code": "P77",
+    "lower_court_code": "1859",
     "name": "Lawrence Probate and Family Court",
     "phone": "(978) 686-9692",
     "has_po_box": false,
@@ -144,6 +151,7 @@
   {
     "fax": "(413) 774-3829",
     "court_code": "P78",
+    "lower_court_code": "1860",
     "name": "Franklin Probate and Family Court",
     "phone": "(413) 774-7011",
     "has_po_box": false,
@@ -164,6 +172,7 @@
   {
     "fax": "(413) 781-5605",
     "court_code": "P79",
+    "lower_court_code": "1861",
     "name": "Hampden Probate and Family Court",
     "phone": "(413) 748-7760",
     "has_po_box": true,
@@ -184,6 +193,7 @@
   {
     "fax": "(413) 584-1132",
     "court_code": "P80",
+    "lower_court_code": "1862",
     "name": "Hampshire Probate and Family Court",
     "phone": "(413) 586-8500",
     "has_po_box": false,
@@ -205,6 +215,7 @@
   {
     "fax": "(781) 528-2318",
     "court_code": "P81",
+    "lower_court_code": "1863",
     "name": "Middlesex Probate and Family Court - South",
     "phone": "(781) 865-4000",
     "has_po_box": false,
@@ -225,6 +236,7 @@
     {
     "fax": "(978) 619-1014",
     "court_code": "P81",
+    "lower_court_code": "1863",
     "name": "Middlesex Probate and Family Court - North",
     "phone": "(978) 656-7700",
     "has_po_box": false,
@@ -245,6 +257,7 @@
   {
     "fax": "(508) 228-3662",
     "court_code": "P75",
+    "lower_court_code": "1864",
     "name": "Nantucket Probate and Family Court",
     "phone": "(508) 228-2669",
     "has_po_box": false,
@@ -265,6 +278,7 @@
   {
     "fax": "(781) 830-4310",
     "court_code": "P82",
+    "lower_court_code": "1865",
     "name": "Norfolk Probate and Family Court",
     "phone": "(781) 830-1200",
     "has_po_box": false,
@@ -285,6 +299,7 @@
   {
     "fax": "(508) 746-6846",
     "court_code": "P83",
+    "lower_court_code": "1866",
     "name": "Plymouth Probate and Family Court",
     "phone": "(508) 747-6204",
     "has_po_box": false,
@@ -305,6 +320,7 @@
   {
     "fax": "(617) 788-8962",
     "court_code": "P84",
+    "lower_court_code": "1867",
     "name": "Suffolk Probate and Family Court",
     "phone": "(617) 788-8301",
     "has_po_box": false,
@@ -325,6 +341,7 @@
   {
     "fax": "(508) 752-6138",
     "court_code": "P85",
+    "lower_court_code": "1868",
     "name": "Worcester Probate and Family Court",
     "phone": "(508) 831-2200",
     "has_po_box": false,

--- a/docassemble/MACourts/data/sources/superior_courts.json
+++ b/docassemble/MACourts/data/sources/superior_courts.json
@@ -2,7 +2,7 @@
   {
     "fax": "",
     "court_code": "72",
-    "lower_court_code": "1870",
+    "tyler_lower_court_code": "1870",
     "name": "Barnstable County Superior Court",
     "phone": "(508) 375-6684",
     "has_po_box": true,
@@ -23,7 +23,7 @@
   {
     "fax": "(413) 442-9190",
     "court_code": "76",
-    "lower_court_code": "1871",
+    "tyler_lower_court_code": "1871",
     "name": "Berkshire County Superior Court",
     "phone": "(413) 499-7487",
     "has_po_box": false,
@@ -44,7 +44,7 @@
   {
     "fax": "(508) 821-9563 ",
     "court_code": "73",
-    "lower_court_code": "1872",
+    "tyler_lower_court_code": "1872",
     "name": "Bristol County Superior Court",
     "phone": "(508) 823-6588",
     "has_po_box": false,
@@ -65,7 +65,7 @@
   {
     "fax": "(508) 821-9563",
     "court_code": "73",
-    "lower_court_code": "1872",
+    "tyler_lower_court_code": "1872",
     "name": "Bristol County Superior Court",
     "phone": "(508) 491-3300",
     "has_po_box": false,
@@ -86,7 +86,7 @@
   {
     "fax": "",
     "court_code": "73",
-    "lower_court_code": "1872",
+    "tyler_lower_court_code": "1872",
     "name": "Bristol County Superior Court",
     "phone": "(508) 996-2051",
     "has_po_box": false,
@@ -108,7 +108,7 @@
   {
     "fax": "",
     "court_code": "74",
-    "lower_court_code": "1873",
+    "tyler_lower_court_code": "1873",
     "name": "Dukes County Superior Court",
     "phone": "(508) 627-4668",
     "has_po_box": true,
@@ -129,7 +129,7 @@
   {
     "fax": "(978) 741-0691",
     "court_code": "77",
-    "lower_court_code": "1874",
+    "tyler_lower_court_code": "1874",
     "name": "Essex County Superior Court",
     "phone": "(978) 744-5500 ",
     "has_po_box": false,
@@ -150,7 +150,7 @@
   {
     "fax": "(978) 687-7869 ",
     "court_code": "77",
-    "lower_court_code": "1874",
+    "tyler_lower_court_code": "1874",
     "name": "Essex County Superior Court",
     "phone": "(978) 242-1900",
     "has_po_box": false,
@@ -171,7 +171,7 @@
   {
     "fax": "(978) 462-0432",
     "court_code": "77",
-    "lower_court_code": "1874",
+    "tyler_lower_court_code": "1874",
     "name": "Essex County Superior Court",
     "phone": "(978) 462-4474",
     "has_po_box": false,
@@ -192,7 +192,7 @@
   {
     "fax": "(413) 774-4770 ",
     "court_code": "78",
-    "lower_court_code": "1875",
+    "tyler_lower_court_code": "1875",
     "name": "Franklin County Superior Court",
     "phone": "(413) 775-7400",
     "has_po_box": false,
@@ -213,7 +213,7 @@
   {
     "fax": "(413) 737-1611",
     "court_code": "79",
-    "lower_court_code": "1869",
+    "tyler_lower_court_code": "1869",
     "name": "Hampden County Superior Court",
     "phone": "(413) 735-6016",
     "has_po_box": true,
@@ -234,7 +234,7 @@
   {
     "fax": "(413) 586-8217",
     "court_code": "80",
-    "lower_court_code": "1876",
+    "tyler_lower_court_code": "1876",
     "name": "Hampshire County Superior Court",
     "phone": "(413) 584-5810",
     "has_po_box": true,
@@ -255,7 +255,7 @@
   {
     "fax": "",
     "court_code": "81",
-    "lower_court_code": "1877",
+    "tyler_lower_court_code": "1877",
     "name": "Middlesex County Superior Court",
     "phone": "(781) 939-2700",
     "has_po_box": false,
@@ -277,7 +277,7 @@
   {
     "fax": "",
     "court_code": "81",
-    "lower_court_code": "1877",
+    "tyler_lower_court_code": "1877",
     "name": "Middlesex County Superior Court",
     "phone": "",
     "has_po_box": false,
@@ -298,7 +298,7 @@
   {
     "fax": "(508) 228-3725",
     "court_code": "75",
-    "lower_court_code": "1878",
+    "tyler_lower_court_code": "1878",
     "name": "Nantucket County Superior Court",
     "phone": "(508) 228-2559",
     "has_po_box": false,
@@ -319,7 +319,7 @@
   {
     "fax": "",
     "court_code": "82",
-    "lower_court_code": "1879",
+    "tyler_lower_court_code": "1879",
     "name": "Norfolk County Superior Court",
     "phone": "(781) 326-1600",
     "has_po_box": false,
@@ -340,7 +340,7 @@
   {
     "fax": "(508) 830-0676",
     "court_code": "83",
-    "lower_court_code": "1881",
+    "tyler_lower_court_code": "1881",
     "name": "Plymouth County Superior Court",
     "phone": "(508) 747-8400",
     "has_po_box": false,
@@ -361,7 +361,7 @@
   {
     "fax": "(508) 584-5639",
     "court_code": "83",
-    "lower_court_code": "1880",
+    "tyler_lower_court_code": "1880",
     "name": "Plymouth County Superior Court",
     "phone": "(508) 583-8250",
     "has_po_box": false,
@@ -382,7 +382,7 @@
   {
     "fax": "",
     "court_code": "84",
-    "lower_court_code": "1882",
+    "tyler_lower_court_code": "1882",
     "name": "Suffolk County Superior Court",
     "phone": "(617) 788-8175",
     "has_po_box": false,
@@ -403,7 +403,7 @@
   {
     "fax": "(508) 798-3216",
     "court_code": "85",
-    "lower_court_code": "1883",
+    "tyler_lower_court_code": "1883",
     "name": "Worcester County Superior Court",
     "phone": "(508) 831-2000",
     "has_po_box": false,

--- a/docassemble/MACourts/data/sources/superior_courts.json
+++ b/docassemble/MACourts/data/sources/superior_courts.json
@@ -2,6 +2,7 @@
   {
     "fax": "",
     "court_code": "72",
+    "lower_court_code": "1870",
     "name": "Barnstable County Superior Court",
     "phone": "(508) 375-6684",
     "has_po_box": true,
@@ -22,6 +23,7 @@
   {
     "fax": "(413) 442-9190",
     "court_code": "76",
+    "lower_court_code": "1871",
     "name": "Berkshire County Superior Court",
     "phone": "(413) 499-7487",
     "has_po_box": false,
@@ -42,6 +44,7 @@
   {
     "fax": "(508) 821-9563 ",
     "court_code": "73",
+    "lower_court_code": "1872",
     "name": "Bristol County Superior Court",
     "phone": "(508) 823-6588",
     "has_po_box": false,
@@ -62,6 +65,7 @@
   {
     "fax": "(508) 821-9563",
     "court_code": "73",
+    "lower_court_code": "1872",
     "name": "Bristol County Superior Court",
     "phone": "(508) 491-3300",
     "has_po_box": false,
@@ -82,6 +86,7 @@
   {
     "fax": "",
     "court_code": "73",
+    "lower_court_code": "1872",
     "name": "Bristol County Superior Court",
     "phone": "(508) 996-2051",
     "has_po_box": false,
@@ -103,6 +108,7 @@
   {
     "fax": "",
     "court_code": "74",
+    "lower_court_code": "1873",
     "name": "Dukes County Superior Court",
     "phone": "(508) 627-4668",
     "has_po_box": true,
@@ -123,6 +129,7 @@
   {
     "fax": "(978) 741-0691",
     "court_code": "77",
+    "lower_court_code": "1874",
     "name": "Essex County Superior Court",
     "phone": "(978) 744-5500 ",
     "has_po_box": false,
@@ -143,6 +150,7 @@
   {
     "fax": "(978) 687-7869 ",
     "court_code": "77",
+    "lower_court_code": "1874",
     "name": "Essex County Superior Court",
     "phone": "(978) 242-1900",
     "has_po_box": false,
@@ -163,6 +171,7 @@
   {
     "fax": "(978) 462-0432",
     "court_code": "77",
+    "lower_court_code": "1874",
     "name": "Essex County Superior Court",
     "phone": "(978) 462-4474",
     "has_po_box": false,
@@ -183,6 +192,7 @@
   {
     "fax": "(413) 774-4770 ",
     "court_code": "78",
+    "lower_court_code": "1875",
     "name": "Franklin County Superior Court",
     "phone": "(413) 775-7400",
     "has_po_box": false,
@@ -203,6 +213,7 @@
   {
     "fax": "(413) 737-1611",
     "court_code": "79",
+    "lower_court_code": "1869",
     "name": "Hampden County Superior Court",
     "phone": "(413) 735-6016",
     "has_po_box": true,
@@ -223,6 +234,7 @@
   {
     "fax": "(413) 586-8217",
     "court_code": "80",
+    "lower_court_code": "1876",
     "name": "Hampshire County Superior Court",
     "phone": "(413) 584-5810",
     "has_po_box": true,
@@ -243,6 +255,7 @@
   {
     "fax": "",
     "court_code": "81",
+    "lower_court_code": "1877",
     "name": "Middlesex County Superior Court",
     "phone": "(781) 939-2700",
     "has_po_box": false,
@@ -264,6 +277,7 @@
   {
     "fax": "",
     "court_code": "81",
+    "lower_court_code": "1877",
     "name": "Middlesex County Superior Court",
     "phone": "",
     "has_po_box": false,
@@ -284,6 +298,7 @@
   {
     "fax": "(508) 228-3725",
     "court_code": "75",
+    "lower_court_code": "1878",
     "name": "Nantucket County Superior Court",
     "phone": "(508) 228-2559",
     "has_po_box": false,
@@ -304,6 +319,7 @@
   {
     "fax": "",
     "court_code": "82",
+    "lower_court_code": "1879",
     "name": "Norfolk County Superior Court",
     "phone": "(781) 326-1600",
     "has_po_box": false,
@@ -324,6 +340,7 @@
   {
     "fax": "(508) 830-0676",
     "court_code": "83",
+    "lower_court_code": "1881",
     "name": "Plymouth County Superior Court",
     "phone": "(508) 747-8400",
     "has_po_box": false,
@@ -344,6 +361,7 @@
   {
     "fax": "(508) 584-5639",
     "court_code": "83",
+    "lower_court_code": "1880",
     "name": "Plymouth County Superior Court",
     "phone": "(508) 583-8250",
     "has_po_box": false,
@@ -364,6 +382,7 @@
   {
     "fax": "",
     "court_code": "84",
+    "lower_court_code": "1882",
     "name": "Suffolk County Superior Court",
     "phone": "(617) 788-8175",
     "has_po_box": false,
@@ -384,6 +403,7 @@
   {
     "fax": "(508) 798-3216",
     "court_code": "85",
+    "lower_court_code": "1883",
     "name": "Worcester County Superior Court",
     "phone": "(508) 831-2000",
     "has_po_box": false,

--- a/docassemble/MACourts/macourts.py
+++ b/docassemble/MACourts/macourts.py
@@ -498,6 +498,7 @@ class MACourtList(DAList):
             court = self.appendObject()
             court.court_code = item.get('court_code')
             court.tyler_code = item.get('tyler_code')
+            court.lower_court_code = item.get('lower_court_code')
             court.name = item['name']
             court.department = court_department
             court.division = parse_division_from_name(item['name'])

--- a/docassemble/MACourts/macourts.py
+++ b/docassemble/MACourts/macourts.py
@@ -498,7 +498,7 @@ class MACourtList(DAList):
             court = self.appendObject()
             court.court_code = item.get('court_code')
             court.tyler_code = item.get('tyler_code')
-            court.lower_court_code = item.get('lower_court_code')
+            court.tyler_lower_court_code = item.get('tyler_lower_court_code')
             court.name = item['name']
             court.department = court_department
             court.division = parse_division_from_name(item['name'])


### PR DESCRIPTION
Added lower court codes from Tyler's "mystery source". 

When e-filing into appeals cases, Tyler expects a very specific code for the lower court that this case is coming from, otherwise it'll reply with `168, Lower court code not found.` We got a confirmation from Tyler that these values aren't publicly available, so for now we'll add them here.

The instructions for finding said "mystery source" are to:
* visit and login to https://massachusetts-stage.tylertech.cloud/ofsweb/ (or the production site, https://massachusetts.tylertech.cloud/ofsweb/)
* Once logged in, under "New Filing", click "Start a new case" (or visit https://massachusetts-stage.tylertech.cloud/OfsWeb/FileAndServeModule/Envelope/AddOrEdit).
* Pull up your browser's network tools, refresh the page, and click "Appeals Court (Single Justice)" for the location field
* Look for the request to `GetEnvelopeCodeConfigs`. The full URL queried is https://massachusetts-stage.tylertech.cloud/OfsWeb/FileAndServeModule/Envelope/GetEnvelopeCodeConfigs?isLocationChanged=true&locationId=120.

The values we need will be in the JSON returned from that endpoint, under `obj["DropDownsLocation"]["LowerCourtCodes"]`.

Also added some Tyler court codes for the housing courts (which we do need to search from).

**Note**: I wasn't able to give Lower Court codes to the "Metro South Housing Courts". Tyler's list only includes:

* Housing Court Central: 1831
* Housing Court Eastern: 1827
* Housing Court, Northeast: 1828
* Housing Court, Southeast: 1829
* Housing Court, Western: 1830

@nonprofittechy, do you have any advice for what to do if someone does need to appeal from the Metro South courts? Or is that something I should ask the Appeals court directly?