### PR TITLE
Fix lower on list

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,22 @@
+name: Run python-only unit tests
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  test-macourts:
+    runs-on: ubuntu-latest
+    name: Run python only unit tests
+    env:
+      ISUNITTEST: true
+    steps:
+      - run: sudo apt-get update && sudo apt-get -y install libcurl4-openssl-dev build-essential python3-dev libldap2-dev libsasl2-dev slapd ldap-utils tox lcov valgrind libzbar0
+      - name: Check
+        uses: actions/checkout@v2
+      - run: pip install virtualenv
+      - run: virtualenv -p python3.8 .venv
+      - run: .venv/bin/pip install -r docassemble/MACourts/requirements.txt
+      - run: .venv/bin/pip install --editable .
+      - run: .venv/bin/python3 -m mypy .
+      - run: .venv/bin/python3 -m unittest discover

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
 
+.hypothesis/
+
 __pycache__/

--- a/docassemble/MACourts/macourts.py
+++ b/docassemble/MACourts/macourts.py
@@ -1038,9 +1038,6 @@ class MACourtList(DAList):
         2.Shapely for constructing Point object
         """
         
-        #load geojson Boston Ward map
-        boston_wards = self.load_boston_wards_from_file(json_path = "boston_wards")
-
         #if location data is not in address object, return empty string
         if (not hasattr(address, 'location')):
             return '',''
@@ -1049,6 +1046,9 @@ class MACourtList(DAList):
         elif address.norm.city.lower() in ['boston','east boston','charlestown']:
             #assign point object
             p1 = Point(address.location.longitude, address.location.latitude)
+
+            #load geojson Boston Ward map
+            boston_wards = self.load_boston_wards_from_file(json_path = "boston_wards")
 
             #find ward containing point object
             ward = boston_wards[[p1.within(boston_wards.geometry[i]) for i in range(len(boston_wards))]]

--- a/docassemble/MACourts/macourts.py
+++ b/docassemble/MACourts/macourts.py
@@ -1,7 +1,6 @@
 from docassemble.base.core import DAObject, DAList
 from docassemble.base.util import path_and_mimetype, Address, LatitudeLongitude, prevent_dependency_satisfaction
 from docassemble.base.legal import Court
-import traceback
 import io, json, re, os, time
 import typing
 from typing import Any, Callable, List, Mapping, Optional, Set, Union, Tuple
@@ -1010,8 +1009,13 @@ class MACourtList(DAList):
                 return None
         return next((court for court in self.elements if court.name.rstrip().lower() == court_name.lower()), None)
 
-    def load_boston_wards_from_file(self, json_path) -> GeoDataFrame:
+    def load_boston_wards_from_file(self, json_path, data_path=None) -> GeoDataFrame:
         """load geojson file for boston wards"""
+        if data_path is None:
+          if hasattr(self, 'data_path'):
+            data_path = self.data_path
+          else:
+            data_path = 'docassemble.MACourts:data/sources/'
         path = path_and_mimetype(os.path.join(self.data_path, json_path+'.geojson'))[0]
         if path is None:
           # fallback, for running on non-docassemble (i.e. unit tests)

--- a/docassemble/MACourts/macourts.py
+++ b/docassemble/MACourts/macourts.py
@@ -2,13 +2,14 @@ from docassemble.base.core import DAObject, DAList
 from docassemble.base.util import path_and_mimetype, Address, LatitudeLongitude, prevent_dependency_satisfaction
 from docassemble.base.legal import Court
 import io, json, re, os, time
-from typing import List, Optional, Set
+from typing import Any, Callable, List, Mapping, Optional, Set, Union, Tuple
 from docassemble.webapp.playground import PlaygroundSection
 from collections.abc import Iterable
 import copy
 
 # Needed for Boston Municipal Court
 import geopandas as gpd
+from geopandas import GeoDataFrame
 from shapely.geometry import Point
 
 __all__= ['MACourt','MACourtList','combined_locations', 'get_year_from_docket_number']
@@ -225,7 +226,7 @@ __all__= ['MACourt','MACourtList','combined_locations', 'get_year_from_docket_nu
 #    #     f.close()
 #    #sources.finalize()
 
-def test_write():
+def test_write() -> str:
     area = PlaygroundSection('sources').get_area()
     fpath = os.path.join(area.directory, "test" + '.json')
     jdata = "test"
@@ -253,10 +254,10 @@ class MACourt(Court):
     def phone_number(self):
       return getattr(self, 'phone')
     
-    def __str__(self):
+    def __str__(self) -> str:
         return str(self.name)
       
-    def _map_info(self):
+    def _map_info(self) -> List[Mapping[str, Any]]:
         the_info = str(self.name)
         the_info += "  [NEWLINE]  " + self.address.block()
         result = {'latitude': self.location.latitude, 'longitude': self.location.longitude, 'info': the_info}
@@ -264,7 +265,7 @@ class MACourt(Court):
             result['icon'] = self.icon
         return [result]
       
-    def short_label(self):
+    def short_label(self) -> str:
       """
       Returns a string that represents a nice, disambiguated label for the court.
       This may not match the court's name. If the name omits city, we
@@ -276,14 +277,14 @@ class MACourt(Court):
       else:
         return str(self.name) + ' (' + self.address.city + ')'
     
-    def short_label_and_address(self):
+    def short_label_and_address(self) -> str:
       """
       Returns a markdown formatted string with the name and address of the court.
       More concise version without description; suitable for a responsive case.
       """
       return '**' + self.short_label() + '**' + '[BR]' + self.address.on_one_line()
     
-    def short_description(self):
+    def short_description(self) -> str:
       """
       Returns a Markdown formatted string that includes the disambiguated name and 
       the description of the court, for inclusion in the results page with radio
@@ -307,8 +308,9 @@ class MACourtList(DAList):
             elif self.courts is True:
                 self.load_courts(data_path=self.data_path)
 
-    def filter_courts(self, court_types):
-        """Return the list of courts matching the specified department(s). E.g., Housing Court. court_types may be list or single court department."""
+    def filter_courts(self, court_types: Union[str, Iterable]) -> Optional[List]:
+        """Return the list of courts matching the specified department(s). 
+        E.g., Housing Court. court_types may be list or single court department."""
         if isinstance(court_types, str):
             return self.filter(department=court_types)
         elif isinstance(court_types, Iterable):
@@ -316,18 +318,17 @@ class MACourtList(DAList):
         else:
             return None
 
-    def get_court_by_code(self, court_code):
+    def get_court_by_code(self, court_code: str) -> Optional[MACourt]:
         """Return a court that has the matching court_code"""
-        # TODO: the court code should always be string, not numeric!
         if isinstance(court_code, str):
             return next((court for court in self if str(court.court_code).lower() == court_code.lower()), None)
         else:
             return None
 
-    def matching_courts(self, address, court_types=None):
+    def matching_courts(self, address: Union[Address, Iterable[Address]], court_types: Union[str, Iterable[str]]=None) -> List[MACourt]:
         """Return a list of courts serving the specified address(es). Optionally limit to one or more types of courts"""
         if isinstance(address, Iterable):
-            courts = set()
+            courts: Set[MACourt] = set()
             for add in address:
                 try:
                     # It's helpful to normalize the address, but it's OK if 
@@ -337,22 +338,21 @@ class MACourtList(DAList):
                     pass
                 res = self.matching_courts_single_address(add, court_types)
                 if isinstance(res, Iterable):
-                    res = filter(lambda el: el is not None, res)
-                    courts.update(res)
+                    courts.update(filter(lambda el: el is not None, res))
                 elif not res is None:
                     courts.add(res)
             return list(courts)
         else:
             return self.matching_courts_single_address(address, court_types)
 
-    def matching_courts_single_address(self, address, court_types=[]):
+    def matching_courts_single_address(self, address: Address, court_types: Union[str, Iterable[str]]=None) -> List[MACourt]:
         try:
           # Don't match Suffolk County in New York, e.g.
           if not address.state.lower() in ["ma","massachusetts"]:
             return []
         except:
           pass
-        court_type_map = {
+        court_type_map: Mapping[str, Callable[[Address], Union[Set[MACourt], MACourt, None]]] = {
             'Housing Court': self.matching_housing_court,
             'District Court': self.matching_district_court,
             'Boston Municipal Court': self.matching_bmc,
@@ -362,20 +362,27 @@ class MACourtList(DAList):
             'Superior Court': self.matching_superior_court,
             'Appeals Court': self.matching_appeals_court,
         }
+        if court_types is None:
+            court_types = []
 
         if isinstance(court_types, str):
           if court_types in court_type_map:
-            return court_type_map[court_types](address)
+            res = court_type_map[court_types](address)
+            if isinstance(res, Iterable):
+              return list(res)
+            elif res is not None:
+              return [res]
+            else:
+              return []
           else:
             return []
         elif isinstance(court_types, Iterable):
-            matches = set()
+            matches: Set[MACourt] = set()
             for court_type in court_types:
               if court_type in court_type_map:
                 res =  court_type_map[court_type](address)
                 if isinstance(res, Iterable):
-                    res = filter(lambda el: el is not None, res)
-                    matches.update(res)
+                    matches.update(filter(lambda el: el is not None, res))
                 elif not res is None:
                     matches.add(res)
               else:
@@ -516,7 +523,7 @@ class MACourtList(DAList):
             court.address.county = item['address']['county']
             court.address.orig_address = item['address'].get('orig_address')
 
-    def matching_juvenile_court(self, address):
+    def matching_juvenile_court(self, address) -> Set[MACourt]:
         """Returns either single matching MACourt object or a set of MACourts"""
         court_name = self.matching_juvenile_court_name(address)
         
@@ -530,20 +537,20 @@ class MACourtList(DAList):
             # one court name, which may match more than one court location. Sessions/sittings don't always get unique names
             return set([court for court in self.elements if court.name.rstrip().lower() == court_name.lower()])
 
-    def matching_juvenile_court_name(self, address, depth=0):
+    def matching_juvenile_court_name(self, address, depth=0) -> Set[str]:
         if depth == 1 and hasattr(address, 'norm_long') and hasattr(address.norm_long, 'city') and hasattr(address.norm_long, 'county'):
             address_to_compare = address.norm_long
         else:
             address_to_compare = address
         if (not hasattr(address_to_compare, 'county')) or (address_to_compare.county.lower().strip() == ''):
-            return ''
+            return set()
 
         matches = []
         # Special case for two areas of Boston -- concurrent with BMC jurisdiction. Need to match these first
         if str(self.matching_bmc(address)) == "West Roxbury Division, Boston Municipal Court":
-            return "West Roxbury Juvenile Court"
+            return set(["West Roxbury Juvenile Court"])
         elif str(self.matching_bmc(address)) == "Dorchester Division, Boston Municipal Court":
-            return "Dorchester Juvenile Court"
+            return set(["Dorchester Juvenile Court"])
         if address_to_compare.city.lower() in ["attleboro", "mansfield", "north attleboro","north attleborough", "norton"]:
             matches.append("Attleboro Juvenile Court")
         if address_to_compare.city.lower() in ["barnstable", "sandwich", "yarmouth"]:
@@ -630,25 +637,22 @@ class MACourtList(DAList):
             return self.matching_juvenile_court_name(address, depth=1)
         return set(matches)
 
-    def matching_probate_and_family_court(self, address) -> Set:
+    def matching_probate_and_family_court(self, address) -> Set[MACourt]:
         """Returns either single matching MACourt object or a set of MACourts"""
         court_names = self.matching_probate_and_family_court_name(address)
-        if isinstance(court_names,Iterable):
-            courts = set()
-            for court_item in court_names:
-                courts.update([court for court in self.elements if court.name.rstrip().lower() == court_item.lower()])
-            return courts
-        else:
-            return set([court for court in self.elements if court.name.rstrip().lower() == court_names.lower()])
+        courts = set()
+        for court_item in court_names:
+            courts.update([court for court in self.elements if court.name.rstrip().lower() == court_item.lower()])
+        return courts
 
-    def matching_probate_and_family_court_name(self, address, depth=0) -> List:
+    def matching_probate_and_family_court_name(self, address, depth=0) -> Set[str]:
         """Multiple P&F courts may serve the same address"""
         if depth==1 and hasattr(address, 'norm_long') and hasattr(address.norm_long, 'city') and hasattr(address.norm_long, 'county'):
             address_to_compare = address.norm_long
         else:
             address_to_compare = address
         if (not hasattr(address_to_compare, 'county')) or (address_to_compare.county.lower().strip() == ''):
-            return []
+            return set()
         matches = []
 
         if (address_to_compare.county.lower() == "barnstable county") or (address_to_compare.city.lower() in ["bourne", "brewster", "chatham", "dennis", "eastham", "falmouth", "harwich", "mashpee", "orleans", "provincetown", "sandwich", "truro", "wellfleet", "yarmouth"]):
@@ -686,9 +690,9 @@ class MACourtList(DAList):
 
         if not matches and depth==0:
             return self.matching_probate_and_family_court_name(address, depth=1)
-        return matches
+        return set(matches)
 
-    def matching_superior_court(self, address):
+    def matching_superior_court(self, address: Address) -> Set[MACourt]:
         """Returns either single matching MACourt object or a set of MACourts"""
         court_name = self.matching_superior_court_name(address)
         # if isinstance(court_name,Iterable):
@@ -697,10 +701,10 @@ class MACourtList(DAList):
         #         courts.update(set([court for court in self.elements if court.name.rstrip().lower() == court_item.lower()]))
         #     return courts
         # else:
-        return [court for court in self.elements if court.name.rstrip().lower() == court_name.lower()]
+        return set([court for court in self.elements if court.name.rstrip().lower() == court_name.lower()])
         # return next ((court for court in self.elements if court.name.rstrip().lower() == court_name.lower()), None)
 
-    def matching_superior_court_name(self, address, depth=0):
+    def matching_superior_court_name(self, address: Address, depth=0) -> str:
         if depth == 1 and hasattr(address, 'norm_long') and hasattr(address.norm_long, 'city') and hasattr(address.norm_long, 'county'):
             address_to_compare = address.norm_long
         else:
@@ -743,26 +747,25 @@ class MACourtList(DAList):
             return self.matching_superior_court_name(address, depth=1)
         return local_superior_court
 
-    def matching_land_court(self, address):
+    def matching_land_court(self, address: Address) -> Optional[MACourt]:
         """There's currently only one Land Court"""
         return next((court for court in self.elements if court.name.rstrip().lower() == 'land court'),None)
       
-    def matching_appeals_court(self, address):
+    def matching_appeals_court(self, address: Address) -> Optional[MACourt]:
         """Two appeals courts: single justice and panel. Returns the single justice one by default."""
         return next((court for court in self.elements if court.name.rstrip().lower() == 'massachusetts appeals court (single justice)'),None)
       
-    def matching_district_court(self, address):
+    def matching_district_court(self, address: Address) -> Set[MACourt]:
         """Return list of MACourts representing the District Court(s) serving the given address"""
         court_name = self.matching_district_court_name(address)
-        if isinstance(court_name,Iterable):
-            courts = set()
-            for court_item in court_name:
-                courts.add(next ((court for court in self.elements if court.name.rstrip().lower() == court_item.lower()),None))
-            return courts
-        else:
-            return [court for court in self.elements if court.name.rstrip().lower() == court_name.lower()]
+        courts = set()
+        for court_item in court_name:
+            matching_obj = next((court for court in self.elements if court.name.rstrip().lower() == court_item.lower()), None)
+            if matching_obj:
+                courts.add(matching_obj)
+        return courts
 
-    def matching_district_court_name(self, address, depth=0):
+    def matching_district_court_name(self, address: Address, depth=0) -> Set[str]:
         """Returns the name of the MACourt(s) representing the district court that covers the specified address.
         Harcoded and must be updated if court jurisdictions or names change. Address must specify county attribute
         
@@ -774,7 +777,7 @@ class MACourtList(DAList):
         else:
             address_to_compare = address
         if (not hasattr(address_to_compare, 'county')) or (address_to_compare.county.lower().strip() == ''):
-            return ['']
+            return set()
         matches = []
         if (address_to_compare.county.lower() == "dukes county") or (address_to_compare.city.lower() in ["edgartown", "oak bluffs", "tisbury", "west tisbury", "chilmark", "aquinnah", "gosnold", "elizabeth islands"]):
             matches.append("Edgartown District Court")
@@ -899,17 +902,17 @@ class MACourtList(DAList):
         if address_to_compare.city.lower() in ["auburn", "millbury", "worcester"]:
             matches.append("Worcester District Court")
         if address_to_compare.city.lower() in ["foxborough", "franklin", "medway", "millis", "norfolk", "plainville", "walpole", "wrentham"]:
-            matches.append("Wrentham District Court")            
+            matches.append("Wrentham District Court")
         if not matches and depth == 0:
             return self.matching_district_court_name(address, depth=1)
-        return matches
+        return set(matches)
 
-    def matching_housing_court(self, address):
+    def matching_housing_court(self, address: Address) -> Optional[MACourt]:
         """Return the MACourt representing the Housing Court serving the given address"""
         court_name = self.matching_housing_court_name(address)
         return next ((court for court in self.elements if court.name.rstrip().lower() == court_name.lower()), None)
 
-    def matching_housing_court_name(self,address, depth=0):
+    def matching_housing_court_name(self, address: Address, depth=0) -> str:
         """Returns the name of the MACourt representing the housing court that covers the specified address.
         Harcoded and must be updated if court jurisdictions or names change. Address must specify county attribute"""
 
@@ -978,7 +981,7 @@ class MACourtList(DAList):
             return self.matching_housing_court_name(address.norm_long, depth=1)
         return local_housing_court
 
-    def matching_bmc(self, address):
+    def matching_bmc(self, address: Address) -> Optional[MACourt]:
         if address.city.lower() in ["winthrop"]:
             # This city is not in Boston but is served by East Boston BMC
             court_name = "East Boston Division, Boston Municipal Court"
@@ -989,14 +992,14 @@ class MACourtList(DAList):
                 return None
         return next ((court for court in self.elements if court.name.rstrip().lower() == court_name.lower()), None)
 
-    def load_boston_wards_from_file(self, json_path, data_path='docassemble.MACourts:data/sources/'):
+    def load_boston_wards_from_file(self, json_path, data_path='docassemble.MACourts:data/sources/') -> GeoDataFrame:
         """load geojson file for boston wards"""
         path = path_and_mimetype(os.path.join(data_path,json_path+'.geojson'))[0]
         wards = gpd.read_file(path)
         
         return wards
 
-    def get_boston_ward_number(self, address):
+    def get_boston_ward_number(self, address: Address) -> Tuple[str, str]:
         """
         This function takes an address object as input,
         filters a geojson file to only include the ward
@@ -1166,7 +1169,11 @@ class MACourtList(DAList):
         if not court_code:
             for key in self._land_court_case_type_code_dict:
                 if key in docket_number:
-                    return [self.matching_land_court(None)]
+                    only_land_court = self.matching_land_court(None)
+                    if only_land_court:
+                      return [only_land_court]
+                    else:
+                      return []
             else:
                 for key in self._sjc_code_dict:
                     if key in docket_number:
@@ -1276,7 +1283,7 @@ def get_sequence_number_from_docket_number(docket_number:str) -> Optional[str]:
     search = find_sequence_number_re.search(docket_number)
     return search.group() if search else None
 
-def parse_division_from_name(court_name):
+def parse_division_from_name(court_name) -> str:
     rules = {
         "District Court": r'(.*)( District Court)',
         "Boston Municipal Court": r"(.*)(, Boston Municipal Court)",
@@ -1323,6 +1330,19 @@ def combined_locations(locations):
     """
 
     places = list()
+    def has_match(locations, other) -> bool:
+        for item in locations:
+            if match(item, other):
+                return True
+        return False
+
+    def match(item, other) -> bool:
+        if not item is None and not other is None:
+            return (
+                round(item.location.latitude, 3) == round(other.location.latitude, 3) and
+                round(item.location.longitude, 3) == round(other.location.longitude, 3)
+            )
+        return False
 
     for location in locations:
         if isinstance(location, DAObject):
@@ -1335,15 +1355,6 @@ def combined_locations(locations):
                             place.description += "  [NEWLINE]  " + str(location)
     return places
 
-def has_match(locations, other):
-    for item in locations:
-        if match(item,other):
-            return True
-    return False
-
-def match(item, other):
-    if not item is None and not other is None:
-        return round(item.location.latitude,3) == round(other.location.latitude,3) and round(item.location.longitude,3) == round(other.location.longitude,3)
 
 #if __name__ == '__main__':
 #    import pprint

--- a/docassemble/MACourts/requirements.txt
+++ b/docassemble/MACourts/requirements.txt
@@ -3,4 +3,5 @@ docassemble.webapp
 geopandas>=0.1.0
 Shapely>=1.0.15
 usaddress>=0.5.10
+hypothesis
 mypy

--- a/docassemble/MACourts/requirements.txt
+++ b/docassemble/MACourts/requirements.txt
@@ -1,0 +1,6 @@
+docassemble.base>=1.4
+docassemble.webapp
+geopandas>=0.1.0
+Shapely>=1.0.15
+usaddress>=0.5.10
+mypy

--- a/docassemble/MACourts/test/test_court_finder.py
+++ b/docassemble/MACourts/test/test_court_finder.py
@@ -1,7 +1,10 @@
-import unittest
-from docassemble.base.util import Address, LatitudeLongitude
-from ..macourts import MACourtList
 from pathlib import Path
+
+import unittest
+from hypothesis import given, strategies as st
+from docassemble.base.util import Address, LatitudeLongitude
+
+from ..macourts import MACourtList
 
 class TestCourtFinder(unittest.TestCase):
     def setUp(self):
@@ -26,7 +29,6 @@ class TestCourtFinder(unittest.TestCase):
                 state="Massachusetts", zip="02135"))
         court_list = self.all_courts.matching_courts(address, court_types=self.court_types)
         court_strings = [str(court.name) for court in court_list]
-        print(court_strings)
         self.assertEqual(len(court_list), 6)
         self.assertIn("Brighton Division, Boston Municipal Court", court_strings)
         self.assertIn("Suffolk County Superior Court", court_strings)
@@ -34,6 +36,95 @@ class TestCourtFinder(unittest.TestCase):
         self.assertIn("Suffolk Probate and Family Court", court_strings)
         self.assertIn("Boston Juvenile Court", court_strings)
         self.assertIn("Land Court", court_strings)
+
+    def test_random_points(self):
+        # previously generated 65 random points that were within the state, and turned those into these addresses
+        # dfd = gpd.GeoDataFrame.from_features(feature) # (rough outline of massachusetts)
+        # x_min, y_min, x_max, y_max = df.total_bounds
+        # x = np.random.uniform(x_min, x_max, 100)
+        # y = np.random.uniform(y_min, y_max, 100)
+        # gpd_points = gpd.GeoSeries(gpd.points_from_xy(x, y))
+        # gpd_points = gpd_points[gpd_points.within(df.unary_union)]
+        # geolocator = Nominatim(user_agent="suffolklitlab_manual")
+        # for p in gpd_points:
+        #   time.sleep(5)
+        #   loc = geolocator.reverse(f"{p.y}, {p.x}")
+        #   l = loc.raw['address']
+        #   print(f"('{l.get('house_number', ''} {l.get('road', '')}', '{l.get('town', l.get('city', ''))}', '{l.get('county')}', '{l.get('postcode')}', {loc.latitude}, {loc.longitude},")
+        for street, city, county, zip, latitude, longitude in (
+           (' Highland Commons West', 'Berlin', 'Worcester County', '01503', 42.3939894991329, -71.60000206953706),
+            (' Tremont Street', 'Dighton', 'Bristol County', '02764', 41.8586440083136, -71.15159239168555),
+            (' Evergreen Street', 'Southbridge', 'Worcester County', '01550', 42.0799458, -72.02040228534332),
+            ('18 Elm Street', 'Freetown', 'Bristol County', '02702', 41.79514055, -71.0633314452663),
+            ('129 Sargent Street', 'Belchertown', 'Hampshire County', '01007', 42.28715805, -72.39633334734003),
+            ('22 Franklin Hill Road', 'Colrain', 'Franklin County', '01340', 42.71362463617108, -72.70252143052237),
+            (' Wheelwright Road', 'Barre', 'Worcester County', '01094', 42.364424, -72.12890951218827),
+            (' Dudley Road', 'Templeton', 'Worcester County', '01468', 42.5400706, -72.08168418092261),
+            (' I 93', 'Boston', 'Suffolk County', '02145', 42.38474243059918, -71.07666832743206),
+            (' Yankee Division Highway', 'Needham', 'Norfolk County', '02494', 42.27724069585515, -71.19971040435486),
+            (' Foundry Street', 'Easton', 'Bristol County', '02375', 42.01411245, -71.1035188918578),
+            ('48 Tor Court', 'Pittsfield', 'Berkshire County', '01202', 42.454234, -73.28252945853066),
+            ('25 Adams Street', 'Medway', 'Norfolk County', '02053', 42.1545494, -71.43164025989681),
+            ('415 Brookfield Road', 'Brimfield', 'Hampden County', '01010', 42.1593942, -72.15071408281906),
+            ('415 Center Street', 'Bridgewater', 'Plymouth County', '02325', 41.9902627, -70.99361821983221),
+            ('26 Broadway Street', 'Westford', 'Middlesex County', '01886', 42.5928758, -71.46285875510262),
+            (' Central Street', 'Holliston', 'Middlesex County', '02054', 42.19507608106604, -71.39058839757578),
+            ('222 Concord Road', 'Lincoln', 'Middlesex County', '01733', 42.410906600000004, -71.3426944),
+            ('106 Howland Road', 'Freetown', 'Bristol County', '02347', 41.7977477, -71.02534964514375),
+            ('55 Pinehurst Avenue', 'Pittsfield', 'Berkshire County', '01201', 42.4840195, -73.25331502805794),
+            ('61 Smith Street', 'Dover', 'Norfolk County', '02030', 42.22700093875156, -71.33199715588512),
+            ('65 Harlow Clark Road', 'Huntington', 'Hampshire County', '01052', 42.2458936, -72.84830370713917),
+            (' Spencer Road', 'Oakham', 'Worcester County', '01068', 42.32618724167509, -72.02539362554955),
+            ('25 Circle View Drive', 'Hampden', 'Hampden County', '01036', 42.075583300000005, -72.45642812801954),
+            ('175 Montague Road', 'Shutesbury', 'Franklin County', '01072', 42.4624147, -72.42725758663953),
+            ('10 Donald Road', 'Hamilton', 'Essex County', '01936', 42.62015785, -70.82576720046993),
+            ('10 Catamount Hill Road Number One', 'Colrain', 'Franklin County', '01340', 42.674503697774504, -72.74969239072699),
+            ('10 Purgatory Road', 'Sutton', 'Worcester County', '01590', 42.13648085, -71.74179041306819),
+            ('4 Paige Road', 'Burlington', 'Middlesex County', '01803', 42.493098700000004, -71.17038274317028),
+            ('60 Carriage House Lane', 'Wrentham', 'Norfolk County', '02093', 42.04160195, -71.37390149442945),
+            (' Pine Hill Road', 'Orange', 'Franklin County', '01364', 42.627378, -72.30768474344747),
+            ('7 Galloway Road', 'Chelmsford', 'Middlesex County', '01863', 42.5906206, -71.39816569656239),
+            ('125 Maximilian Drive', 'Granby', 'Hampshire County', '01033', 42.27031635, -72.48946252987403),
+            ('15 Chanterwood Road', 'Lee', 'Berkshire County', '01264', 42.28536405, -73.19914315),
+            ('1576 Shirley Road', 'Lancaster', 'Worcester County', '01464', 42.51381365, -71.66523721038719),
+            ('85 Meaghan Circle', 'Taunton', 'Bristol County', '02347', 41.853822199999996, -70.99174316201103),
+            ('46 Morse Road', 'Holland', 'Hampden County', '01521', 42.08623088769841, -72.16216836352413),
+            (' Partridge Hill Road', 'Charlton', 'Worcester County', '01571', 42.088394550000004, -71.93787017396735),
+            ('444 East Windsor Road', 'Windsor', 'Berkshire County', '01270', 42.49057795, -73.02528131660799),
+            ('33 Shaws Lane', 'Springfield', 'Hampden County', '01104', 42.12966305, -72.56302424924249),
+            ('West Sturbridge Road', 'East Brookfield', 'Worcester County', '01506', 42.182487449999996, -72.05902183935248),
+            ('40 Maureen Way', 'Millville', 'Worcester County', '01529', 42.054910050000004, -71.58685925),
+            ('14 Kimball Avenue', 'Wenham', 'Essex County', '01984', 42.60853335, -70.9096519548315),
+            ('356 East Street', 'Sharon', 'Norfolk County', '02067', 42.1259197, -71.15284198942624),
+            ('Yankee Division Highway', 'Quincy', 'Norfolk County', '02368', 42.2161895, -71.0523257),
+            ('71 Bligh Street', 'Tewksbury', 'Middlesex County', '01876', 42.62888615, -71.20285122390203),
+            ('175 Millwood Street', 'Framingham', 'Middlesex County', '01701', 42.32151435, -71.4593585337083),
+            ('50 Lorraine Drive', 'North Adams', 'Berkshire County', '01247', 42.709677400000004, -73.10311456300539),
+            ('Main Road', 'Tyringham', 'Berkshire County', '01264', 42.2769872, -73.22355983545783),
+            ('15 Randall Road', 'Rochester', 'Plymouth County', '02770', 41.77068965, -70.82974667822991),
+            ('8 Anthony Drive', 'Hinsdale', 'Berkshire County', '01235', 42.400403, -73.1225440305746),
+            ('Primary Trail', 'Westford', 'Middlesex County', '08163', 42.62669499516589, -71.42622469506479),
+            ('Ledges Trail', 'Petersham', 'Worcester County', '01366', 42.4943804, -72.1723491),
+            ('Loop Trail', 'Boylston', 'Worcester County', '01505', 42.36290785, -71.72461856990755),
+            ('3 Samual Harrington Road', 'Westborough', 'Worcester County', '01581', 42.29925195, -71.58548016591237),
+            ('1099 Ashby West Road', 'Fitchburg', 'Worcester County', '01431', 42.63033245, -71.83718909827459),
+            ('58 Ring Road', 'Kingston', 'Plymouth County', '02364', 41.98339745, -70.76900261113018),
+        ):
+            address = Address(address=street, city=city, county=county, state="Massachusetts", zip=zip)
+            address.norm_long = address
+            address.norm = address
+            address.location = LatitudeLongitude(latitude=latitude, longitude=longitude),
+            court_list = self.all_courts.matching_courts(address, court_types=self.court_types)
+            self.assertGreaterEqual(len(court_list), 1)
+
+
+    @given(address=st.text(), city=st.text(), county=st.text(), zip=st.from_regex(r"[0-9]{5}"))
+    def test_search_all(self, address, city, county, zip):
+        address = Address(address=address, city=city, county=county, state="Massachusetts", zip=zip)
+        address.norm_long = address
+        address.norm = address
+        self.all_courts.matching_courts(address, court_types=self.court_types)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docassemble/MACourts/test/test_court_finder.py
+++ b/docassemble/MACourts/test/test_court_finder.py
@@ -1,0 +1,39 @@
+import unittest
+from docassemble.base.util import Address, LatitudeLongitude
+from ..macourts import MACourtList
+from pathlib import Path
+
+class TestCourtFinder(unittest.TestCase):
+    def setUp(self):
+      data_path = data_path=Path(__file__).resolve().parent.joinpath('../data/sources')
+      self.all_courts = MACourtList(data_path=data_path)
+      self.all_courts.load_courts(
+          ['housing_courts','bmc','district_courts','superior_courts','land_court','juvenile_courts','probate_and_family_courts','appeals_court'],
+      )
+      self.court_types = ["District Court", "Boston Municipal Court","Housing Court","Superior Court", "Probate and Family Court","Juvenile Court","Land Court"]
+
+    def test_search_in_bristol(self):
+        address = Address(address="91 Highland Road", city="Swansea", state="Massachusetts", county="Bristol County", zip="02777")
+        court_list = self.all_courts.matching_probate_and_family_court(address)
+        self.assertGreaterEqual(len(court_list), 1)
+        self.assertEqual(list(court_list)[0].name, "Bristol Probate and Family Court")
+
+    def test_search_boston(self):
+        address = Address(address="1234 Soldiers Field Road", city="Boston", county="Suffolk County", 
+            state="Massachusetts", zip="02135", 
+            location=LatitudeLongitude(latitude=42.3641126, longitude=-71.1364048),
+            norm=Address(address="1234 Soliders Field Road", city="Boston", county="Suffolk Courty", 
+                state="Massachusetts", zip="02135"))
+        court_list = self.all_courts.matching_courts(address, court_types=self.court_types)
+        court_strings = [str(court.name) for court in court_list]
+        print(court_strings)
+        self.assertEqual(len(court_list), 6)
+        self.assertIn("Brighton Division, Boston Municipal Court", court_strings)
+        self.assertIn("Suffolk County Superior Court", court_strings)
+        self.assertIn("Eastern Housing Court", court_strings)
+        self.assertIn("Suffolk Probate and Family Court", court_strings)
+        self.assertIn("Boston Juvenile Court", court_strings)
+        self.assertIn("Land Court", court_strings)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Avoid problems arising from things like #39, systematically, by:
* running mypy on each commit
* running unit tests on each commit
* adding unit tests to catch the specific error that was happening
* some experimental usage of [hypothesis](https://hypothesis.readthedocs.io/en/latest/quickstart.html) (not sure that it was useful here, but I did want to have some documented uses of it, and I couldn't find any in our existing repos), and
* random geolocation testing: tests ~60 randomly chosen locations in Massachusetts to ensure that at least one court is available

Not a ton of specific errors caught, but a few improvements made:
* standardized the types that we return from our functions, sometimes it was sets, sometimes strings. I made each function consistent, although there are some functions (like that for appeals or the land court) that just return `MACourt | None` instead of a set.
* don't load the geojson wards (which takes 300ms on my machine) if we don't use them