### PR TITLE
Don't use `address.norm_long` unless it exists

### DIFF
--- a/docassemble/MACourts/macourts.py
+++ b/docassemble/MACourts/macourts.py
@@ -782,7 +782,7 @@ class MACourtList(DAList):
         
         # Try one time to match the normalized address instead of the 
         # literal provided address if first match fails
-        if depth == 0 and not local_housing_court:
+        if depth == 0 and not local_housing_court and hasattr(address, "norm_long"):
             return self.matching_housing_court_name(address.norm_long, depth=1)
         return local_housing_court
 


### PR DESCRIPTION
Causes an error if unable to find an address for the housing court.

This interview will error without this patch, if you enter a fake street address and city:

```yaml
---
include:
  - docassemble.AssemblyLine:assembly_line.yml
  - docassemble.MassAccess:massaccess.yml
---
mandatory: True
code: |
  users
  users[0].address.address
  trial_court
```