### PR TITLE
Updated tyler court codes to match production

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,26 @@ Unittests:
 ```bash
 python3 -m unittest discover docassemble
 ```
+
+## How to update `lower_court_code`
+
+When e-filing into appeals cases, Tyler expects a very specific code for the lower court that the case is being appealed from. We got a confirmation from Tyler that these values aren't publicly available, so for now they are stored in the `tyler_lower_court_code` and `tyler_prod_lower_court_code` attributes
+for each object.
+
+These values may occasionally change. And again, as we've gotten little information from Tyler about these values, we don't know when these values change. The only indication is if you start receiving `168, Lower court code not found` errors when filing.
+
+To update these values:
+* visit and login to https://massachusetts-stage.tylertech.cloud/ofsweb/ (or the production site, https://massachusetts.tylertech.cloud/ofsweb/)
+* Once logged in, under "New Filing", click "Start a new case" (or visit https://massachusetts-stage.tylertech.cloud/OfsWeb/FileAndServeModule/Envelope/AddOrEdit).
+* Pull up your browser's network tools, refresh the page, and set the location field to be "Appeals Court (Single Justice)".
+* In your browser's network tools, look for the request to `GetEnvelopeCodeConfigs`. The full URL queried is https://massachusetts-stage.tylertech.cloud/OfsWeb/FileAndServeModule/Envelope/GetEnvelopeCodeConfigs?isLocationChanged=true&locationId=120.
+
+The values we need will be in the JSON returned from that endpoint, under `obj["DropDownsLocation"]["LowerCourtCodes"]`.
+
+**Note**: I wasn't able to give Lower Court codes to the "Metro South Housing Courts". Tyler's list only includes:
+
+* Housing Court Central
+* Housing Court Eastern
+* Housing Court, Northeast
+* Housing Court, Southeast
+* Housing Court, Western

--- a/docassemble/MACourts/data/sources/housing_courts.json
+++ b/docassemble/MACourts/data/sources/housing_courts.json
@@ -196,7 +196,7 @@
     ],
     "description": "The Metro South Housing Court - Brockton Session serves Abington, Avon, Bellingham, Braintree, Bridgewater, Brockton, Canton, Cohasset, Dedham, Dover, East Bridgewater, Eastham, Foxborough, Franklin, Holbrook, Medfield, Medway, Millis, Milton, Needham, Norfolk, Norwood, Plainville, Quincy, Randolph, Sharon, Stoughton, Walpole, Wellesley, West Bridgewater, Westwood, Weymouth, Whitman, and Wrentham.",
     "court_code": "H82",
-    "tyler_code": "1550"
+    "tyler_code": "1265"
   },
   {
     "fax": "(508) 894-4166",
@@ -224,7 +224,7 @@
     ],
     "description": "This court serves all cities and towns in Norfolk County. Filings only permitted at this location on days court is in session (currently Fridays).",
     "court_code": "H82",
-    "tyler_code": "1550"
+    "tyler_code": "1265"
   },
   {
     "fax": "",
@@ -652,7 +652,6 @@
   {
     "fax": "(508)362-0290",
     "court_code": "H83",
-    "tyler_code": "1556",
     "name": "Southeast Housing Court - Barnstable session",
     "phone": "(508)375-6967",
     "has_po_box": true,
@@ -676,13 +675,13 @@
       }
     ],
     "description": "The Barnstable session of the Southeast Housing court is located in Barnstable, MA and serves Barnstable, Nantucket, and Dukes counties.",
+    "tyler_code": "555:CI",
     "tyler_lower_court_code": "1829",
     "tyler_prod_lower_court_code": "7058"
   },
   {
     "fax": "",
     "court_code": "H84",
-    "tyler_code": "537",
     "name": "Eastern Housing Court - Chelsea Session",
     "phone": "(617)788-8485",
     "has_po_box": false,
@@ -706,6 +705,7 @@
       }
     ],
     "description": "The Chelsea session of Eastern Housing Court is located in Chelsea District Court and serves Chelsea, Revere, Winthrop and East Boston.",
+    "tyler_code": "537",
     "tyler_lower_court_code": "1827",
     "tyler_prod_lower_court_code": "7056"
   }


### PR DESCRIPTION
There was a production issue over the holidays due to the tyler court code changing for the Metro South court. This PR (along with some additional) safety in the Eviction interview should fix it.

Additionally added the documentation on how to update the related `lower_court_code`s in the README.md, as requested in https://github.com/GBLS/docassemble-MACourts/pull/67#pullrequestreview-1331304890. I checked and they were the same on production now.