### PR TITLE
Stop docassemble from pre-loading tests

### DIFF
--- a/docassemble/MACourts/test/test_court_finder.py
+++ b/docassemble/MACourts/test/test_court_finder.py
@@ -1,3 +1,4 @@
+# do not pre-load
 from pathlib import Path
 
 import unittest


### PR DESCRIPTION
Some clean up I had made to this package earlier; if the `hypothesis` testing library isn't on the docassemble server, docassemble will error each time it restarts as it tries to pre-load the testing file with a class in it.

Turning this off avoids that error log (which for a while I thought was causing issues with new logs not being made on my local DA server, but that may have been misguided).