### PR TITLE
Sets the Tyler lower court code on Metro South

### DIFF
--- a/docassemble/MACourts/data/sources/housing_courts.json
+++ b/docassemble/MACourts/data/sources/housing_courts.json
@@ -196,7 +196,9 @@
     ],
     "description": "The Metro South Housing Court - Brockton Session serves Abington, Avon, Bellingham, Braintree, Bridgewater, Brockton, Canton, Cohasset, Dedham, Dover, East Bridgewater, Eastham, Foxborough, Franklin, Holbrook, Medfield, Medway, Millis, Milton, Needham, Norfolk, Norwood, Plainville, Quincy, Randolph, Sharon, Stoughton, Walpole, Wellesley, West Bridgewater, Westwood, Weymouth, Whitman, and Wrentham.",
     "court_code": "H82",
-    "tyler_code": "1265"
+    "tyler_code": "1265",
+    "tyler_lower_court_code": "1829",
+    "tyler_prod_lower_court_code": "7058"
   },
   {
     "fax": "(508) 894-4166",
@@ -224,7 +226,9 @@
     ],
     "description": "This court serves all cities and towns in Norfolk County. Filings only permitted at this location on days court is in session (currently Fridays).",
     "court_code": "H82",
-    "tyler_code": "1265"
+    "tyler_code": "1265",
+    "tyler_lower_court_code": "1829",
+    "tyler_prod_lower_court_code": "7058"
   },
   {
     "fax": "",


### PR DESCRIPTION
Have seen several submissions to the Motion to Stay Eviction interview that have the Metro South - Brockton court recently in production. This court did not previously have a `tyler_lower_court_code` because it didn't exist in the Tyler list (see  https://github.com/SuffolkLITLab/docassemble-MACourts?tab=readme-ov-file#how-to-update-lower_court_code for more information about this code).

In communications with the Trial Court since then about other interviews, they have said that

> the [Housing] Southeast Brockton Session no longer being accessible. Cases that were previously part of that division are now classified under Metro South.

Given that Tyler has not yet updated the lower court codes to accurately match the current state of the court division, and that the Metro south courts have been operating long enough to expect appeals from those courts to begin appearing, I think it makes the most sense to use the reverse of this statement, and set the Metro South courts to use the Housing Southeast code.

This is a production issue, so if we aren't sure this is the correct solution, we should reach out to the Appeals court and directly ask what they think the solution should be.