### PR TITLE
Ensure that addresses with `norm_long` also contain `city`

### DIFF
--- a/docassemble/MACourts/macourts.py
+++ b/docassemble/MACourts/macourts.py
@@ -3205,7 +3205,7 @@ class MACourtList(DAList):
 
         # Try one time to match the normalized address instead of the
         # literal provided address if first match fails
-        if depth == 0 and not local_housing_court and hasattr(address, "norm_long"):
+        if depth == 0 and not local_housing_court and hasattr(address, "norm_long") and hasattr(address.norm_long, "city"):
             return self.matching_housing_court_name(address.norm_long, depth=1)
         return local_housing_court
 

--- a/docassemble/MACourts/test/test_court_finder.py
+++ b/docassemble/MACourts/test/test_court_finder.py
@@ -591,6 +591,24 @@ class TestCourtFinder(unittest.TestCase):
         address.norm = address
         self.all_courts.matching_courts(address, court_types=self.court_types)
 
+    @given(address=st.text(), city=st.text(), county=st.text(), zip=st.from_regex(r"[0-9]{5}"))
+    def test_search_housing(self, address, city, county, zip):
+        # Main address needs both city and county attribute to make it to all other cases
+        address = Address(address=address, city=city, county=county, state="Massachusetts", zip=zip)
+        # 1. Norm long without city or county
+        address.norm_long = Address(address=address, state="Massachusetts", zip=zip)
+        address.norm = address
+        self.all_courts.matching_housing_court_name(address)
+
+        # 2. Norm long without county
+        address.norm_long = Address(address=address, city=city, state="Massachusetts", zip=zip) 
+        self.all_courts.matching_housing_court_name(address)
+
+        # 3. Norm long without city
+        address.norm_long = Address(address=address, county=county, state="Massachusetts", zip=zip)
+        self.all_courts.matching_housing_court_name(address)
+
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The `norm_long` address doesn't always have attributes you would assume, like `city`, `county`, zip code, etc.

Happens sometimes when addresses can be validated, but only contain geographic information for some reason. They won't contain the city. Has happened a few times in prod and finally was able to reproduce it when fixing bugs in `MACourtLocator` (can trigger when searching for a city that isn't matched, i.e. garbage inputs).

I believe is related to this: https://github.com/SuffolkLITLab/docassemble-AssemblyLine/issues/959. 