### PR TITLE
Add params to the "filter" function on MACourtLoader

### DIFF
--- a/docassemble/MACourts/macourts.py
+++ b/docassemble/MACourts/macourts.py
@@ -323,15 +323,36 @@ class MACourtList(DAList):
             elif self.courts is True:
                 self.load_courts(data_path=self.data_path)
 
-    def filter_courts(self, court_types: Union[str, Iterable]) -> Optional[List]:
+    def filter_courts(
+        self,
+        court_types: Union[str, Iterable],
+        column: str = "department",
+        search_column: Optional[str] = None,
+        search_func: Optional[Callable[[str], bool]] = None
+    ) -> Optional[list]:
         """Return the list of courts matching the specified department(s).
-        E.g., Housing Court. court_types may be list or single court department."""
+        E.g., Housing Court. court_types may be list or single court department.
+        
+        Args:
+          court_types (Union[str, Iterable]): the types of courts that will be returned
+          column (str): the column that "court_types" is directly compared against
+          search_column (Optional[str]): the column that the "search_func" will be given
+          search_func (Optional[Callable[[str], bool]]): a general function that will be used to filter the courts.
+
+        Returns:
+          a list of the courts that match the params given, None if court_types in invalid
+        """
         if isinstance(court_types, str):
-            return self.filter(department=court_types)
+            filtered = [court for court in self.elements if getattr(court, column) == court_types]
         elif isinstance(court_types, Iterable):
-            return [court for court in self.elements if court.department in court_types]
+            filtered = [court for court in self.elements if getattr(court, column) in court_types]
         else:
             return None
+        
+        if search_func and search_column:
+            filtered = [court for court in filtered if search_func(getattr(court, search_column))]
+        
+        return filtered 
 
     def get_court_by_code(self, court_code: str) -> Optional[MACourt]:
         """Return a court that has the matching court_code"""

--- a/docassemble/MACourts/test/test_court_finder.py
+++ b/docassemble/MACourts/test/test_court_finder.py
@@ -92,6 +92,12 @@ class TestCourtFinder(unittest.TestCase):
         self.assertEqual(len(court_list), 1)
         self.assertEqual(court_list[0].name, "Supreme Judicial Court")
 
+    def test_find_specific_tyler(self):
+        court_list = self.all_courts.filter_courts(court_types="District Court", search_column="tyler_code", search_func=lambda r: r == "805")
+        self.assertEqual(len(court_list), 1)
+        self.assertEqual(court_list[0].name, "Brockton District Court")
+
+
     def test_random_points(self):
         # previously generated 65 random points that were within the state, and turned those into these addresses
         # dfd = gpd.GeoDataFrame.from_features(feature) # (rough outline of massachusetts)


### PR DESCRIPTION
Makes it slightly closer to the ALCourtLoader class, and lets us filter MA Courts by their attributes (with a general lambda) without extracting all of the court objects first.

Necessary for e-filing so we can search for and courts that are currently have e-filing enabled.

Open to changing the implementation after looking at it for a bit. I did intend for it to match the ALCourtLoader methods exactly, but I did need a generic lambda (as I'm checking if a specific column is in a collection of valid values), so the API is a little redundant at points. Some thoughts that I had:


* a different function that only takes a lambda that operates on the court object and all of it's attributes directly (would impede implementing #119 (or just make it a lot slow) a bit though)
* make court_type / column support multiple filters, so the court type / tyler code search would be just additional passes of a filter (wouldn't need callable / lambda support then)
* some combination of the above (separate function, full object, only supporting iterables / `in` and not lambdas)