### PR TITLE
Fix docassemble 1.9/1.10 geocoder compatibility

### DIFF
--- a/docassemble/MACourts/macourts.py
+++ b/docassemble/MACourts/macourts.py
@@ -1,5 +1,5 @@
-from docassemble.base.functions import server
 from docassemble.base.geocode import GoogleV3GeoCoder
+from docassemble.base.config import daconfig
 from docassemble.base.core import DAObject, DAList
 from docassemble.base.util import (
     path_and_mimetype,
@@ -15,6 +15,7 @@ from docassemble.webapp.playground import PlaygroundSection
 from collections.abc import Iterable
 import copy
 import math
+from types import SimpleNamespace
 from functools import lru_cache
 
 # Needed for Boston Municipal Court
@@ -41,6 +42,22 @@ def test_write() -> str:
     return fpath
 
 
+def _make_google_v3_geocoder() -> GoogleV3GeoCoder:
+    """Instantiate the Google geocoder across supported docassemble versions.
+
+    docassemble 1.9 expects a ``server`` object with ``daconfig``.  Newer
+    docassemble versions read ``daconfig`` directly and do not accept the
+    keyword.  Keep the compatibility handling local so importing this module
+    does not depend on the private ``functions.server`` symbol.
+    """
+    try:
+        return GoogleV3GeoCoder()
+    except KeyError as err:
+        if err.args != ("server",):
+            raise
+        return GoogleV3GeoCoder(server=SimpleNamespace(daconfig=daconfig))
+
+
 def try_to_populate_county(address: Address, force: bool = False) -> None:
     """
     Jurisdiction depends on exactly matching names for county, city, etc. but we can't ask
@@ -65,7 +82,7 @@ def try_to_populate_county(address: Address, force: bool = False) -> None:
         return
     county = "Unknown"
     try:
-        geocoder = GoogleV3GeoCoder(server=server)
+        geocoder = _make_google_v3_geocoder()
         geocoder.initialize()
     except:
         address.county = county

--- a/docassemble/MACourts/test/test_geocoder_compat.py
+++ b/docassemble/MACourts/test/test_geocoder_compat.py
@@ -1,0 +1,46 @@
+import unittest
+from unittest.mock import patch
+
+from .. import macourts
+
+
+class ModernGeoCoder:
+    def __init__(self):
+        self.initialized_without_server = True
+
+
+class LegacyGeoCoder:
+    def __init__(self, **kwargs):
+        if "server" not in kwargs:
+            raise KeyError("server")
+        self.server = kwargs["server"]
+
+
+class BrokenGeoCoder:
+    def __init__(self):
+        raise KeyError("unrelated constructor failure")
+
+
+class TestGoogleV3GeoCoderCompatibility(unittest.TestCase):
+    def test_modern_geocoder_is_constructed_without_server(self):
+        with patch.object(macourts, "GoogleV3GeoCoder", ModernGeoCoder):
+            geocoder = macourts._make_google_v3_geocoder()
+
+        self.assertIsInstance(geocoder, ModernGeoCoder)
+        self.assertTrue(geocoder.initialized_without_server)
+
+    def test_legacy_geocoder_gets_a_server_config_adapter(self):
+        with patch.object(macourts, "GoogleV3GeoCoder", LegacyGeoCoder):
+            geocoder = macourts._make_google_v3_geocoder()
+
+        self.assertIsInstance(geocoder, LegacyGeoCoder)
+        self.assertIs(geocoder.server.daconfig, macourts.daconfig)
+
+    def test_unrelated_key_error_is_not_hidden(self):
+        with patch.object(macourts, "GoogleV3GeoCoder", BrokenGeoCoder):
+            with self.assertRaisesRegex(KeyError, "unrelated constructor failure"):
+                macourts._make_google_v3_geocoder()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docassemble/MACourts/test/test_geocoder_compat.py
+++ b/docassemble/MACourts/test/test_geocoder_compat.py
@@ -1,3 +1,4 @@
+# do not pre-load
 import unittest
 from unittest.mock import patch
 


### PR DESCRIPTION
## What changed

- Removed the direct import of the private `docassemble.base.functions.server` symbol.
- Added a local `_make_google_v3_geocoder()` factory.
- Uses `GoogleV3GeoCoder()` on newer docassemble versions.
- On v1.9.x, catches only the known `KeyError("server")` and retries with a minimal `SimpleNamespace(daconfig=daconfig)` adapter.
- Added focused tests for the modern constructor, the v1.9 constructor, and unrelated `KeyError` propagation.

## Reproduction

On a v1.10 server, importing `docassemble.MACourts.macourts` failed immediately because v1.10 no longer exports `server` from `docassemble.base.functions`:

```
ImportError: cannot import name 'server' from 'docassemble.base.functions'
```

The v1.9.13 source was also checked: its `GeoCoder.__init__()` requires `kwargs["server"]`, while `GoogleV3GeoCoder` reads the Google API key from `self.server.daconfig`.

## Validation

- The compatibility tests cover both constructor shapes and pass in an isolated runner.
- Syntax and diff checks pass.
- The package was installed in the localhost v1.10 environment and imported successfully.
- The package was installed only in the apps-dev Playground, not globally. The Playground interview initialized successfully as `docassemble.playground10:test_get_court_by_code.yml`.
- The earlier `encoding without a string argument` report was reproduced on both servers, then traced to the diagnostic API client omitting the `secret` returned by `/api/session/new`. Supplying that secret made the same interview return HTTP 200 on both servers; no MACourts code change is needed for that symptom.